### PR TITLE
WIP: run against dbus-broker bench

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,6 +266,7 @@ dependencies = [
  "hex",
  "nix",
  "ntest",
+ "quick-xml",
  "rand",
  "serde",
  "tokio",
@@ -1192,6 +1193,16 @@ checksum = "747761bc3dc48f9a34553bf65605cf6cb6288ba219f3450b4275dbd81539551a"
 dependencies = [
  "bytes",
  "prost",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81b9228215d82c7b61490fec1de287136b5de6f5700f6e58ea9ad61a7964ca51"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ path = "src/bin/busd.rs"
 #zbus = { git = "https://github.com/dbus2/zbus/", features = ["tokio"], default-features = false }
 zbus = { version = "3.14.1", features = ["tokio"], default-features = false }
 tokio = { version = "1.19.2", features = ["macros", "rt-multi-thread", "signal", "tracing", "fs" ] }
-clap = { version = "4.0.18", features = ["derive"] }
+clap = { version = "4.3", features = ["derive"] }
 tracing = "0.1.34"
 tracing-subscriber = { version = "0.3.11", features = ["env-filter" , "fmt", "ansi"], default-features = false, optional = true }
 anyhow = "1.0.58"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ console-subscriber = { version = "0.1.8", optional = true }
 hex = "0.4.3"
 xdg-home = "1.0.0"
 rand = "0.8.5"
+quick-xml = { version = "0.29", features = ["serialize", "overlapped-lists"] }
 
 [target.'cfg(unix)'.dependencies]
 nix = "0.26.0"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,392 @@
+use std::fmt::Write;
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Context};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Default, Serialize, Deserialize, Clone, PartialEq)]
+#[serde(rename = "busconfig", rename_all = "snake_case")]
+pub struct BusConfig {
+    #[serde(rename = "$value", default)]
+    pub elements: Vec<Element>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum Element {
+    User(String),
+    Type(String),
+    Fork,
+    Syslog,
+    KeepUmask,
+    Listen(String),
+    #[serde(rename = "pidfile")]
+    PIDFile(String),
+    #[serde(rename = "includedir")]
+    IncludeDir(String),
+    #[serde(rename = "standard_session_servicedirs")]
+    StandardSessionServiceDirs,
+    #[serde(rename = "standard_system_servicedirs")]
+    StandardSystemServiceDirs,
+    #[serde(rename = "servicedir")]
+    ServiceDir(String),
+    #[serde(rename = "servicehelper")]
+    ServiceHelper(String),
+    Auth(String),
+    Include(Include),
+    Policy(Policy),
+    Limit(Limit),
+    #[serde(rename = "selinux")]
+    SELinux(SELinux),
+    #[serde(rename = "apparmor")]
+    AppArmor(AppArmor),
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct Include {
+    #[serde(rename = "$value")]
+    pub content: String,
+    #[serde(rename = "@ignore_missing", deserialize_with = "de_yes_no", default)]
+    pub ignore_missing: Option<bool>,
+    #[serde(
+        rename = "@if_selinux_enabled",
+        deserialize_with = "de_yes_no",
+        default
+    )]
+    pub if_selinux_enabled: Option<bool>,
+    #[serde(
+        rename = "@selinux_root_relative",
+        deserialize_with = "de_yes_no",
+        default
+    )]
+    pub selinux_root_relative: Option<bool>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct Policy {
+    #[serde(rename = "$value")]
+    pub rules: Vec<Rule>,
+    #[serde(rename = "@context")]
+    pub context: Option<PolicyContext>,
+    #[serde(rename = "@user")]
+    pub user: Option<String>,
+    #[serde(rename = "@group")]
+    pub group: Option<String>,
+    #[serde(
+        rename = "@at_console",
+        deserialize_with = "de_yes_no_true_false",
+        default
+    )]
+    pub at_console: Option<bool>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum PolicyContext {
+    Default,
+    Mandatory,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum Rule {
+    #[serde(deserialize_with = "de_allow_deny")]
+    Allow(AllowDeny),
+    Deny(AllowDeny),
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct AllowDeny {
+    #[serde(rename = "@send_interface")]
+    pub send_interface: Option<String>,
+    #[serde(rename = "@send_member")]
+    pub send_member: Option<String>,
+    #[serde(rename = "@send_error")]
+    pub send_error: Option<String>,
+    #[serde(rename = "@send_destination")]
+    pub send_destination: Option<String>,
+    #[serde(rename = "@send_path")]
+    pub send_path: Option<String>,
+    #[serde(rename = "@send_type")]
+    pub send_type: Option<String>,
+    #[serde(
+        rename = "@send_requested_reply",
+        deserialize_with = "de_true_false",
+        default
+    )]
+    pub send_requested_reply: Option<bool>,
+    #[serde(
+        rename = "@send_broadcast",
+        deserialize_with = "de_true_false",
+        default
+    )]
+    pub send_broadcast: Option<bool>,
+    #[serde(rename = "@receive_interface")]
+    pub receive_interface: Option<String>,
+    #[serde(rename = "@receive_member")]
+    pub receive_member: Option<String>,
+    #[serde(rename = "@receive_error")]
+    pub receive_error: Option<String>,
+    #[serde(rename = "@receive_sender")]
+    pub receive_sender: Option<String>,
+    #[serde(rename = "@receive_path")]
+    pub receive_path: Option<String>,
+    #[serde(rename = "@receive_type")]
+    pub receive_type: Option<String>,
+    #[serde(
+        rename = "@receive_requested_reply",
+        deserialize_with = "de_true_false",
+        default
+    )]
+    pub receive_requested_reply: Option<bool>,
+    #[serde(rename = "@eavesdrop", deserialize_with = "de_true_false", default)]
+    pub eavesdrop: Option<bool>,
+    #[serde(rename = "@min_fds")]
+    pub min_fds: Option<String>,
+    #[serde(rename = "@max_fds")]
+    pub max_fds: Option<String>,
+    #[serde(rename = "@own")]
+    pub own: Option<String>,
+    #[serde(rename = "@own_prefix")]
+    pub own_prefix: Option<String>,
+    #[serde(rename = "@user")]
+    pub user: Option<String>,
+    #[serde(rename = "@group")]
+    pub group: Option<String>,
+    #[serde(rename = "@log", deserialize_with = "de_true_false", default)]
+    pub log: Option<bool>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct Limit {
+    #[serde(rename = "$value", deserialize_with = "de_limit")]
+    pub value: usize,
+    #[serde(rename = "@name")]
+    pub name: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct SELinux {
+    #[serde(rename = "$value")]
+    pub associates: Vec<Associate>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[serde(rename = "associate")]
+pub struct Associate {
+    #[serde(rename = "@own")]
+    pub own: String,
+    #[serde(rename = "@context")]
+    pub context: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct AppArmor {
+    mode: AppArmorMode,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum AppArmorMode {
+    Required,
+    Enabled,
+    Diabled,
+}
+
+impl BusConfig {
+    /// Write the XML document to writer.
+    pub fn to_writer<W: Write>(&self, writer: W) -> Result<(), anyhow::Error> {
+        Ok(quick_xml::se::to_writer(writer, self)?)
+    }
+
+    /// Read a config from the filesystem, with <include*> support.
+    pub fn read<P>(path: P) -> Result<Self, anyhow::Error>
+    where
+        P: AsRef<Path>,
+    {
+        use std::collections::HashSet;
+
+        fn join_paths<P>(parent: Option<&Path>, path: P) -> PathBuf
+        where
+            P: AsRef<Path>,
+        {
+            let path = path.as_ref();
+            match parent {
+                Some(p) => p.join(path),
+                None => path.to_path_buf(),
+            }
+        }
+
+        pub fn read_visited<P>(
+            path: P,
+            visited: &mut HashSet<PathBuf>,
+        ) -> Result<BusConfig, anyhow::Error>
+        where
+            P: AsRef<Path>,
+        {
+            let path: &Path = path.as_ref();
+            if !visited.insert(path.to_owned()) {
+                bail!("File {} visited recursively", path.display());
+            }
+            let file = std::fs::File::open(path)
+                .with_context(|| format!("Failed to read from {}", path.display()))?;
+            let reader = std::io::BufReader::new(file);
+            let parent = path.parent();
+            let config: BusConfig = quick_xml::de::from_reader(reader)?;
+            let mut elements = Vec::new();
+            for e in config.elements {
+                match e {
+                    Element::Include(inc) => {
+                        if inc.if_selinux_enabled.unwrap_or(false) {
+                            // FIXME: add selinux support
+                            continue;
+                        }
+
+                        let p = join_paths(parent, inc.content);
+                        match read_visited(p, visited) {
+                            Ok(mut config) => {
+                                elements.append(&mut config.elements);
+                            }
+                            Err(e) => {
+                                if let (Some(true), Some(e)) =
+                                    (inc.ignore_missing, e.downcast_ref::<std::io::Error>())
+                                {
+                                    if e.kind() == std::io::ErrorKind::NotFound {
+                                        continue;
+                                    }
+                                }
+                                return Err(e);
+                            }
+                        }
+                    }
+                    Element::IncludeDir(inc) => {
+                        let path = join_paths(parent, inc);
+                        let Ok(entries) = std::fs::read_dir(path) else {
+                            continue;
+                        };
+                        for entry in entries {
+                            let mut config = read_visited(entry?.path(), visited)?;
+                            elements.append(&mut config.elements);
+                        }
+                    }
+                    _ => elements.push(e),
+                }
+            }
+            Ok(BusConfig { elements })
+        }
+
+        let mut visited = HashSet::new();
+        read_visited(path, &mut visited)
+    }
+}
+
+impl<'a> TryFrom<&'a str> for BusConfig {
+    type Error = anyhow::Error;
+
+    fn try_from(s: &'a str) -> Result<BusConfig, anyhow::Error> {
+        Ok(quick_xml::de::from_str(s)?)
+    }
+}
+
+impl TryFrom<&BusConfig> for String {
+    type Error = anyhow::Error;
+
+    fn try_from(c: &BusConfig) -> Result<String, anyhow::Error> {
+        let mut writer = String::new();
+        c.to_writer(&mut writer)?;
+        Ok(writer)
+    }
+}
+
+fn de_limit<'de, D>(deserializer: D) -> Result<usize, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let v = usize::deserialize(deserializer)?;
+    if v > i32::MAX as _ {
+        Err(serde::de::Error::custom("Limit is > i32::MAX"))
+    } else {
+        Ok(v)
+    }
+}
+
+fn de_allow_deny<'de, D>(deserializer: D) -> Result<AllowDeny, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let v = AllowDeny::deserialize(deserializer)?;
+    let has_send = v.send_interface.is_some()
+        || v.send_member.is_some()
+        || v.send_error.is_some()
+        || v.send_destination.is_some()
+        || v.send_path.is_some()
+        || v.send_type.is_some()
+        || v.send_requested_reply.is_some()
+        || v.send_broadcast.is_some();
+
+    let has_recv = v.receive_interface.is_some()
+        || v.receive_member.is_some()
+        || v.receive_error.is_some()
+        || v.receive_sender.is_some()
+        || v.receive_path.is_some()
+        || v.receive_type.is_some()
+        || v.receive_requested_reply.is_some();
+
+    if !has_send
+        && !has_recv
+        && v.eavesdrop.is_none()
+        && v.min_fds.is_none()
+        && v.max_fds.is_none()
+        && v.own.is_none()
+        && v.own_prefix.is_none()
+        && v.user.is_none()
+        && v.group.is_none()
+        && v.log.is_none()
+    {
+        return Err(serde::de::Error::custom("No limit attribute set"));
+    }
+
+    if has_send && has_recv {
+        return Err(serde::de::Error::custom(
+            "send and receive attributes cannot be combined",
+        ));
+    }
+
+    Ok(v)
+}
+
+fn de_yes_no<'de, D>(deserializer: D) -> Result<Option<bool>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let v = String::deserialize(deserializer)?;
+    match v.as_str() {
+        "yes" => Ok(Some(true)),
+        "no" => Ok(Some(false)),
+        _ => Err(serde::de::Error::custom("Invalid boolean")),
+    }
+}
+
+fn de_true_false<'de, D>(deserializer: D) -> Result<Option<bool>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let v = String::deserialize(deserializer)?;
+    match v.as_str() {
+        "true" => Ok(Some(true)),
+        "false" => Ok(Some(false)),
+        _ => Err(serde::de::Error::custom("Invalid boolean")),
+    }
+}
+
+fn de_yes_no_true_false<'de, D>(deserializer: D) -> Result<Option<bool>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let v = String::deserialize(deserializer)?;
+    match v.as_str() {
+        "yes" | "true" => Ok(Some(true)),
+        "no" | "false" => Ok(Some(false)),
+        _ => Err(serde::de::Error::custom("Invalid boolean")),
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,7 @@
-use std::fmt::Write;
-use std::path::{Path, PathBuf};
+use std::{
+    fmt::Write,
+    path::{Path, PathBuf},
+};
 
 use anyhow::{bail, Context};
 use serde::{Deserialize, Serialize};

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,6 +11,164 @@ pub struct BusConfig {
     pub elements: Vec<Element>,
 }
 
+impl BusConfig {
+    /// The well-known type of the message bus. Currently known values are
+    /// "system" and "session".
+    ///
+    /// Note: the last <type> wins.
+    pub fn r#type(&self) -> Option<&str> {
+        self.elements.iter().rev().find_map(|e| match e {
+            Element::Type(e) => Some(e.as_str()),
+            _ => None,
+        })
+    }
+
+    /// The user account the daemon should run as, as either a username or a
+    /// UID.
+    ///
+    /// Note: the last <user> wins.
+    pub fn user(&self) -> Option<&str> {
+        self.elements.iter().rev().find_map(|e| match e {
+            Element::User(e) => Some(e.as_str()),
+            _ => None,
+        })
+    }
+
+    /// The bus daemon becomes a real daemon (forks into the background, etc.)
+    pub fn fork(&self) -> bool {
+        self.elements.iter().any(|e| matches!(e, Element::Fork))
+    }
+
+    /// The bus daemon keeps its original umask when forking.
+    pub fn keep_umask(&self) -> bool {
+        self.elements
+            .iter()
+            .any(|e| matches!(e, Element::KeepUmask))
+    }
+
+    /// The bus daemon will log to syslog.
+    pub fn syslog(&self) -> bool {
+        self.elements.iter().any(|e| matches!(e, Element::Syslog))
+    }
+
+    /// The bus daemon will write its pid to the specified file.
+    ///
+    /// Note: the last <pidfile> wins.
+    pub fn pidfile(&self) -> Option<&str> {
+        self.elements.iter().rev().find_map(|e| match e {
+            Element::PIDFile(e) => Some(e.as_str()),
+            _ => None,
+        })
+    }
+
+    /// Addresses that the bus should listen on.
+    pub fn listen_addresses(&self) -> Vec<&str> {
+        self.elements
+            .iter()
+            .filter_map(|e| match e {
+                Element::Listen(e) => Some(e.as_str()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Add an address that the bus should listen on.
+    pub fn add_listen_address(&mut self, address: String) {
+        self.elements.push(Element::Listen(address));
+    }
+
+    /// Permitted authorization mechanisms.
+    pub fn auths(&self) -> Vec<&str> {
+        self.elements
+            .iter()
+            .filter_map(|e| match e {
+                Element::Auth(e) => Some(e.as_str()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Directory to search for .service files.
+    pub fn service_dirs(&self) -> Vec<&str> {
+        self.elements
+            .iter()
+            .filter_map(|e| match e {
+                Element::ServiceDir(e) => Some(e.as_str()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Requests a standard set of session service directories.
+    pub fn standard_session_service_dirs(&self) -> bool {
+        self.elements
+            .iter()
+            .any(|e| matches!(e, Element::StandardSessionServiceDirs))
+    }
+
+    /// Requests a standard set of system service directories.
+    pub fn standard_system_service_dirs(&self) -> bool {
+        self.elements
+            .iter()
+            .any(|e| matches!(e, Element::StandardSystemServiceDirs))
+    }
+
+    /// Specifies the setuid helper that is used to launch system daemons with
+    /// an alternate user.
+    ///
+    /// Note: the last <servicehelper> wins.
+    pub fn service_helper(&self) -> Option<&str> {
+        self.elements.iter().rev().find_map(|e| match e {
+            Element::ServiceHelper(e) => Some(e.as_str()),
+            _ => None,
+        })
+    }
+
+    /// Resource limits.
+    pub fn limits(&self) -> Vec<&Limit> {
+        self.elements
+            .iter()
+            .filter_map(|e| match e {
+                Element::Limit(e) => Some(e),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Security policies.
+    pub fn policies(&self) -> Vec<&Policy> {
+        self.elements
+            .iter()
+            .filter_map(|e| match e {
+                Element::Policy(e) => Some(e),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// SELinux settings.
+    pub fn selinux(&self) -> Vec<&SELinux> {
+        self.elements
+            .iter()
+            .filter_map(|e| match e {
+                Element::SELinux(e) => Some(e),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// AppArmor settings.
+    pub fn apparmor(&self) -> Vec<&AppArmor> {
+        self.elements
+            .iter()
+            .filter_map(|e| match e {
+                Element::AppArmor(e) => Some(e),
+                _ => None,
+            })
+            .collect()
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum Element {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod bus;
+pub mod config;
 pub mod fdo;
 pub mod name_registry;
 pub mod peer;

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -1,0 +1,300 @@
+use busd::config::{BusConfig, Element};
+use std::error::Error;
+use std::path::PathBuf;
+
+#[test]
+fn test_se() -> Result<(), Box<dyn Error>> {
+    let mut elements = vec![];
+    elements.push(Element::User("foo".into()));
+    let c = BusConfig { elements };
+    let _config = String::try_from(&c);
+    Ok(())
+}
+
+#[test]
+fn test_de() -> Result<(), Box<dyn Error>> {
+    let input = r##"
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+  <user>foo</user>
+  <listen>unix:path=/foo/bar</listen>
+  <listen>unix:path=/foo/bar2</listen>
+</busconfig>
+"##;
+    let _config = BusConfig::try_from(input)?;
+    Ok(())
+}
+
+#[test]
+fn valid_basic() -> Result<(), Box<dyn Error>> {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.push("tests/data/valid-config-files/basic.conf");
+    let config = BusConfig::read(path)?;
+    let n_listen = config
+        .elements
+        .iter()
+        .filter(|e| matches!(e, Element::Listen(_)))
+        .count();
+    assert_eq!(n_listen, 4);
+    Ok(())
+}
+
+#[test]
+fn valid_check_own_rules() -> Result<(), Box<dyn Error>> {
+    let input = include_str!("data/valid-config-files/check-own-rules.conf");
+    let _config = BusConfig::try_from(input)?;
+    Ok(())
+}
+
+#[test]
+fn valid_entities() -> Result<(), Box<dyn Error>> {
+    let input = include_str!("data/valid-config-files/entities.conf");
+    let _config = BusConfig::try_from(input)?;
+    Ok(())
+}
+
+#[test]
+fn valid_listen_unix_runtime() -> Result<(), Box<dyn Error>> {
+    let input = include_str!("data/valid-config-files/listen-unix-runtime.conf");
+    let _config = BusConfig::try_from(input)?;
+    Ok(())
+}
+
+#[test]
+fn valid_many_rules() -> Result<(), Box<dyn Error>> {
+    let input = include_str!("data/valid-config-files/many-rules.conf");
+    let _config = BusConfig::try_from(input)?;
+    Ok(())
+}
+
+#[test]
+fn valid_minimal() -> Result<(), Box<dyn Error>> {
+    let input = include_str!("data/valid-config-files/minimal.conf");
+    let _config = BusConfig::try_from(input)?;
+    Ok(())
+}
+
+#[test]
+fn valid_session() -> Result<(), Box<dyn Error>> {
+    let input = include_str!("data/valid-config-files/session.conf");
+    let _config = BusConfig::try_from(input)?;
+    Ok(())
+}
+
+#[test]
+fn valid_standard_session_dirs() -> Result<(), Box<dyn Error>> {
+    let input = include_str!("data/valid-config-files/standard-session-dirs.conf");
+    let _config = BusConfig::try_from(input)?;
+    Ok(())
+}
+
+#[test]
+fn invalid_apparmor_bad_attribute() -> Result<(), Box<dyn Error>> {
+    let input = include_str!("data/invalid-config-files/apparmor-bad-attribute.conf");
+    assert!(BusConfig::try_from(input).is_err());
+    Ok(())
+}
+
+#[test]
+fn invalid_bad_attribute() -> Result<(), Box<dyn Error>> {
+    let input = include_str!("data/invalid-config-files/bad-attribute.conf");
+    assert!(BusConfig::try_from(input).is_err());
+    Ok(())
+}
+
+// FIXME: how to #[serde(deny_unknown_fields)]
+#[test]
+#[ignore]
+fn invalid_bad_attribute_2() -> Result<(), Box<dyn Error>> {
+    let input = include_str!("data/invalid-config-files/bad-attribute-2.conf");
+    assert!(BusConfig::try_from(input).is_err());
+    Ok(())
+}
+
+#[test]
+fn invalid_bad_element() -> Result<(), Box<dyn Error>> {
+    let input = include_str!("data/invalid-config-files/bad-element.conf");
+    assert!(BusConfig::try_from(input).is_err());
+    Ok(())
+}
+
+#[test]
+fn invalid_bad_limit() -> Result<(), Box<dyn Error>> {
+    let input = include_str!("data/invalid-config-files/bad-limit.conf");
+    assert!(BusConfig::try_from(input).is_err());
+    Ok(())
+}
+
+#[test]
+fn invalid_badselinux_1() -> Result<(), Box<dyn Error>> {
+    let input = include_str!("data/invalid-config-files/badselinux-1.conf");
+    assert!(BusConfig::try_from(input).is_err());
+    Ok(())
+}
+
+#[test]
+fn invalid_badselinux_2() -> Result<(), Box<dyn Error>> {
+    let input = include_str!("data/invalid-config-files/badselinux-2.conf");
+    assert!(BusConfig::try_from(input).is_err());
+    Ok(())
+}
+
+#[test]
+fn invalid_circular_1() -> Result<(), Box<dyn Error>> {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.push("tests/data/invalid-config-files/circular-1.conf");
+    assert!(BusConfig::read(path).is_err());
+    Ok(())
+}
+
+#[test]
+fn invalid_circular_2() -> Result<(), Box<dyn Error>> {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.push("tests/data/invalid-config-files/circular-2.conf");
+    assert!(BusConfig::read(path).is_err());
+    Ok(())
+}
+
+#[test]
+fn invalid_double_attribute() -> Result<(), Box<dyn Error>> {
+    let input = include_str!("data/invalid-config-files/double-attribute.conf");
+    assert!(BusConfig::try_from(input).is_err());
+    Ok(())
+}
+
+// FIXME: needs some semantic knowledge?
+#[ignore]
+#[test]
+fn invalid_impossible_send() -> Result<(), Box<dyn Error>> {
+    let input = include_str!("data/invalid-config-files/impossible-send.conf");
+    assert!(BusConfig::try_from(input).is_err());
+    Ok(())
+}
+
+#[test]
+fn invalid_limit_no_name() -> Result<(), Box<dyn Error>> {
+    let input = include_str!("data/invalid-config-files/limit-no-name.conf");
+    assert!(BusConfig::try_from(input).is_err());
+    Ok(())
+}
+
+#[test]
+fn invalid_ludicrous_limit() -> Result<(), Box<dyn Error>> {
+    let input = include_str!("data/invalid-config-files/ludicrous-limit.conf");
+    assert!(BusConfig::try_from(input).is_err());
+    Ok(())
+}
+
+#[test]
+fn invalid_negative_limit() -> Result<(), Box<dyn Error>> {
+    let input = include_str!("data/invalid-config-files/negative-limit.conf");
+    assert!(BusConfig::try_from(input).is_err());
+    Ok(())
+}
+
+#[test]
+fn invalid_non_numeric_limit() -> Result<(), Box<dyn Error>> {
+    let input = include_str!("data/invalid-config-files/non-numeric-limit.conf");
+    assert!(BusConfig::try_from(input).is_err());
+    Ok(())
+}
+
+#[test]
+fn invalid_not_well_formed() -> Result<(), Box<dyn Error>> {
+    let input = include_str!("data/invalid-config-files/not-well-formed.conf");
+    assert!(BusConfig::try_from(input).is_err());
+    Ok(())
+}
+
+#[test]
+fn invalid_policy_bad_at_console() -> Result<(), Box<dyn Error>> {
+    let input = include_str!("data/invalid-config-files/policy-bad-at-console.conf");
+    assert!(BusConfig::try_from(input).is_err());
+    Ok(())
+}
+
+#[test]
+fn invalid_policy_bad_attribute() -> Result<(), Box<dyn Error>> {
+    let input = include_str!("data/invalid-config-files/policy-bad-attribute.conf");
+    assert!(BusConfig::try_from(input).is_err());
+    Ok(())
+}
+
+#[test]
+fn invalid_policy_bad_context() -> Result<(), Box<dyn Error>> {
+    let input = include_str!("data/invalid-config-files/policy-bad-context.conf");
+    assert!(BusConfig::try_from(input).is_err());
+    Ok(())
+}
+
+// FIXME: how to #[serde(deny_unknown_fields)]
+#[ignore]
+#[test]
+fn invalid_policy_bad_rule_attribute() -> Result<(), Box<dyn Error>> {
+    let input = include_str!("data/invalid-config-files/policy-bad-rule-attribute.conf");
+    assert!(BusConfig::try_from(input).is_err());
+    Ok(())
+}
+
+#[test]
+fn invalid_policy_contradiction() -> Result<(), Box<dyn Error>> {
+    let input = include_str!("data/invalid-config-files/policy-contradiction.conf");
+    assert!(BusConfig::try_from(input).is_err());
+    Ok(())
+}
+
+// FIXME: needs some semantic knowledge?
+#[ignore]
+#[test]
+fn invalid_policy_member_no_path() -> Result<(), Box<dyn Error>> {
+    let input = include_str!("data/invalid-config-files/policy-member-no-path.conf");
+    assert!(BusConfig::try_from(input).is_err());
+    Ok(())
+}
+
+// FIXME: needs some semantic knowledge?
+#[ignore]
+#[test]
+fn invalid_policy_mixed() -> Result<(), Box<dyn Error>> {
+    let input = include_str!("data/invalid-config-files/policy-mixed.conf");
+    assert!(BusConfig::try_from(input).is_err());
+    Ok(())
+}
+
+#[test]
+fn invalid_policy_no_attributes() -> Result<(), Box<dyn Error>> {
+    let input = include_str!("data/invalid-config-files/policy-no-attributes.conf");
+    assert!(BusConfig::try_from(input).is_err());
+    Ok(())
+}
+
+#[test]
+fn invalid_policy_no_rule_attribute() -> Result<(), Box<dyn Error>> {
+    let input = include_str!("data/invalid-config-files/policy-no-rule-attribute.conf");
+    assert!(BusConfig::try_from(input).is_err());
+    Ok(())
+}
+
+#[test]
+fn invalid_send_and_receive() -> Result<(), Box<dyn Error>> {
+    let input = include_str!("data/invalid-config-files/send-and-receive.conf");
+    assert!(BusConfig::try_from(input).is_err());
+    Ok(())
+}
+
+#[test]
+fn invalid_truncated_file() -> Result<(), Box<dyn Error>> {
+    let input = include_str!("data/invalid-config-files/truncated-file.conf");
+    assert!(BusConfig::try_from(input).is_err());
+    Ok(())
+}
+
+// FIXME: needs some semantic knowledge?
+#[ignore]
+#[test]
+fn invalid_unknown_limit() -> Result<(), Box<dyn Error>> {
+    let input = include_str!("data/invalid-config-files/unknown-limit.conf");
+    assert!(BusConfig::try_from(input).is_err());
+    Ok(())
+}

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -1,6 +1,5 @@
 use busd::config::{BusConfig, Element};
-use std::error::Error;
-use std::path::PathBuf;
+use std::{error::Error, path::PathBuf};
 
 #[test]
 fn test_se() -> Result<(), Box<dyn Error>> {

--- a/tests/data/invalid-config-files/apparmor-bad-attribute.conf
+++ b/tests/data/invalid-config-files/apparmor-bad-attribute.conf
@@ -1,0 +1,4 @@
+<busconfig>
+  <listen>tcp:port=1234</listen>
+  <apparmor enforcement_style="Judge Dredd"/>
+</busconfig>

--- a/tests/data/invalid-config-files/apparmor-bad-mode.conf
+++ b/tests/data/invalid-config-files/apparmor-bad-mode.conf
@@ -1,0 +1,4 @@
+<busconfig>
+  <listen>tcp:port=1234</listen>
+  <apparmor mode="plaintive"/>
+</busconfig>

--- a/tests/data/invalid-config-files/bad-attribute-2.conf
+++ b/tests/data/invalid-config-files/bad-attribute-2.conf
@@ -1,0 +1,3 @@
+<busconfig>
+  <listen carefully="yes">tcp:port=1234</listen>
+</busconfig>

--- a/tests/data/invalid-config-files/bad-attribute.conf
+++ b/tests/data/invalid-config-files/bad-attribute.conf
@@ -1,0 +1,4 @@
+<busconfig>
+  <listen>tcp:port=1234</listen>
+  <limit wildebeest="gnu">5000</limit>
+</busconfig>

--- a/tests/data/invalid-config-files/bad-element.conf
+++ b/tests/data/invalid-config-files/bad-element.conf
@@ -1,0 +1,4 @@
+<busconfig>
+  <listen>tcp:port=1234</listen>
+  <bees/>
+</busconfig>

--- a/tests/data/invalid-config-files/bad-limit.conf
+++ b/tests/data/invalid-config-files/bad-limit.conf
@@ -1,0 +1,4 @@
+<busconfig>
+  <listen>tcp:port=1234</listen>
+  <limit name="max_names_per_connection">as many as you like</limit>
+</busconfig>

--- a/tests/data/invalid-config-files/badselinux-1.conf
+++ b/tests/data/invalid-config-files/badselinux-1.conf
@@ -1,0 +1,10 @@
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+  <user>mybususer</user>
+  <listen>unix:path=/foo/bar</listen>
+  <listen>tcp:port=1234</listen>
+  <includedir>basic.d</includedir>
+  <servicedir>/usr/share/foo</servicedir>
+  <include selinux_root_relative="jomoma">blah</include>
+</busconfig>

--- a/tests/data/invalid-config-files/badselinux-2.conf
+++ b/tests/data/invalid-config-files/badselinux-2.conf
@@ -1,0 +1,10 @@
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+  <user>mybususer</user>
+  <listen>unix:path=/foo/bar</listen>
+  <listen>tcp:port=1234</listen>
+  <includedir>basic.d</includedir>
+  <servicedir>/usr/share/foo</servicedir>
+  <include if_selinux_enabled="moo">blah</include>
+</busconfig>

--- a/tests/data/invalid-config-files/circular-1.conf
+++ b/tests/data/invalid-config-files/circular-1.conf
@@ -1,0 +1,4 @@
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN" "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+<include>circular-1.conf</include>
+</busconfig>

--- a/tests/data/invalid-config-files/circular-2.conf
+++ b/tests/data/invalid-config-files/circular-2.conf
@@ -1,0 +1,4 @@
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN" "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+<include>circular-3.conf</include>
+</busconfig>

--- a/tests/data/invalid-config-files/circular-3.conf
+++ b/tests/data/invalid-config-files/circular-3.conf
@@ -1,0 +1,4 @@
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN" "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+<include>circular-2.conf</include>
+</busconfig>

--- a/tests/data/invalid-config-files/double-attribute.conf
+++ b/tests/data/invalid-config-files/double-attribute.conf
@@ -1,0 +1,4 @@
+<busconfig>
+  <listen>tcp:port=1234</listen>
+  <limit name="max_incoming_bytes" name="max_incoming_bytes">5000</limit>
+</busconfig>

--- a/tests/data/invalid-config-files/impossible-send.conf
+++ b/tests/data/invalid-config-files/impossible-send.conf
@@ -1,0 +1,6 @@
+<busconfig>
+  <listen>unix:path=/foo</listen>
+  <policy context="default">
+    <allow send_broadcast="true" send_destination="com.example.Bees"/>
+  </policy>
+</busconfig>

--- a/tests/data/invalid-config-files/limit-no-name.conf
+++ b/tests/data/invalid-config-files/limit-no-name.conf
@@ -1,0 +1,4 @@
+<busconfig>
+  <listen>tcp:port=1234</listen>
+  <limit/>
+</busconfig>

--- a/tests/data/invalid-config-files/ludicrous-limit.conf
+++ b/tests/data/invalid-config-files/ludicrous-limit.conf
@@ -1,0 +1,5 @@
+<busconfig>
+  <listen>tcp:port=1234</listen>
+  <!-- Chosen to be out-of-range for int, but not long (on 64-bit) -->
+  <limit name="max_names_per_connection">3123123123</limit>
+</busconfig>

--- a/tests/data/invalid-config-files/negative-limit.conf
+++ b/tests/data/invalid-config-files/negative-limit.conf
@@ -1,0 +1,4 @@
+<busconfig>
+  <listen>tcp:port=1234</listen>
+  <limit name="max_names_per_connection">-1</limit>
+</busconfig>

--- a/tests/data/invalid-config-files/non-numeric-limit.conf
+++ b/tests/data/invalid-config-files/non-numeric-limit.conf
@@ -1,0 +1,4 @@
+<busconfig>
+  <listen>tcp:port=1234</listen>
+  <limit name="max_names_per_connection">bees</limit>
+</busconfig>

--- a/tests/data/invalid-config-files/not-well-formed.conf
+++ b/tests/data/invalid-config-files/not-well-formed.conf
@@ -1,0 +1,5 @@
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+  <user>mybususer</foo>
+</busconfig>

--- a/tests/data/invalid-config-files/policy-bad-at-console.conf
+++ b/tests/data/invalid-config-files/policy-bad-at-console.conf
@@ -1,0 +1,4 @@
+<busconfig>
+  <listen>tcp:port=1234</listen>
+  <policy at_console="somewhere in the vicinity"/>
+</busconfig>

--- a/tests/data/invalid-config-files/policy-bad-attribute.conf
+++ b/tests/data/invalid-config-files/policy-bad-attribute.conf
@@ -1,0 +1,4 @@
+<busconfig>
+  <listen>tcp:port=1234</listen>
+  <policy hat="top"/>
+</busconfig>

--- a/tests/data/invalid-config-files/policy-bad-context.conf
+++ b/tests/data/invalid-config-files/policy-bad-context.conf
@@ -1,0 +1,4 @@
+<busconfig>
+  <listen>tcp:port=1234</listen>
+  <policy context="apropos of nothing"/>
+</busconfig>

--- a/tests/data/invalid-config-files/policy-bad-rule-attribute.conf
+++ b/tests/data/invalid-config-files/policy-bad-rule-attribute.conf
@@ -1,0 +1,6 @@
+<busconfig>
+  <listen>tcp:port=1234</listen>
+  <policy context="default">
+    <allow species="stoat"/>
+  </policy>
+</busconfig>

--- a/tests/data/invalid-config-files/policy-contradiction.conf
+++ b/tests/data/invalid-config-files/policy-contradiction.conf
@@ -1,0 +1,4 @@
+<busconfig>
+  <listen>tcp:port=1234</listen>
+  <policy user="root" at_console="true"/>
+</busconfig>

--- a/tests/data/invalid-config-files/policy-member-no-path.conf
+++ b/tests/data/invalid-config-files/policy-member-no-path.conf
@@ -1,0 +1,6 @@
+<busconfig>
+  <listen>tcp:port=1234</listen>
+  <policy context="default">
+    <deny send_member="Reboot"/>
+  </policy>
+</busconfig>

--- a/tests/data/invalid-config-files/policy-mixed.conf
+++ b/tests/data/invalid-config-files/policy-mixed.conf
@@ -1,0 +1,6 @@
+<busconfig>
+  <listen>tcp:port=1234</listen>
+  <policy context="default">
+    <allow user="*" own="com.example.Bees"/>
+  </policy>
+</busconfig>

--- a/tests/data/invalid-config-files/policy-no-attributes.conf
+++ b/tests/data/invalid-config-files/policy-no-attributes.conf
@@ -1,0 +1,4 @@
+<busconfig>
+  <listen>tcp:port=1234</listen>
+  <policy/>
+</busconfig>

--- a/tests/data/invalid-config-files/policy-no-rule-attribute.conf
+++ b/tests/data/invalid-config-files/policy-no-rule-attribute.conf
@@ -1,0 +1,6 @@
+<busconfig>
+  <listen>tcp:port=1234</listen>
+  <policy context="default">
+    <allow/>
+  </policy>
+</busconfig>

--- a/tests/data/invalid-config-files/send-and-receive.conf
+++ b/tests/data/invalid-config-files/send-and-receive.conf
@@ -1,0 +1,6 @@
+<busconfig>
+  <listen>unix:path=/foo</listen>
+  <policy context="default">
+    <allow receive_type="signal" send_destination="com.example.Bees"/>
+  </policy>
+</busconfig>

--- a/tests/data/invalid-config-files/truncated-file.conf
+++ b/tests/data/invalid-config-files/truncated-file.conf
@@ -1,0 +1,9 @@
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+  <user>mybususer</user>
+  <listen>unix:path=/foo/bar</listen>
+  <listen>tcp:port=1234</listen>
+  <includedir>basic.d</includedir>
+  <servicedir>/usr/share/foo</servicedir>
+  <include ignore_missing="y

--- a/tests/data/invalid-config-files/unknown-limit.conf
+++ b/tests/data/invalid-config-files/unknown-limit.conf
@@ -1,0 +1,4 @@
+<busconfig>
+  <listen>tcp:port=1234</listen>
+  <limit name="max_bees">5000</limit>
+</busconfig>

--- a/tests/data/valid-config-files/basic.conf
+++ b/tests/data/valid-config-files/basic.conf
@@ -1,0 +1,32 @@
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+  <user>mybususer</user>
+  <listen>unix:path=/foo/bar</listen>
+  <listen>tcp:port=1234</listen>
+  <includedir>basic.d</includedir>
+  <servicedir>/usr/share/foo</servicedir>
+  <include ignore_missing="yes">nonexistent.conf</include>
+  <policy context="default">
+    <allow user="*"/>
+  </policy>
+
+  <limit name="max_incoming_bytes">5000</limit>
+  <limit name="max_outgoing_bytes">5000</limit>
+  <limit name="max_message_size">300</limit>
+  <limit name="service_start_timeout">5000</limit>
+  <limit name="auth_timeout">6000</limit>
+  <limit name="max_completed_connections">50</limit>
+  <limit name="max_incomplete_connections">80</limit>
+  <limit name="max_connections_per_user">64</limit>
+  <limit name="max_pending_service_starts">64</limit>
+  <limit name="max_names_per_connection">256</limit>
+
+  <selinux>
+        <associate own="org.freedesktop.FrobationaryMeasures"
+         context="my_selinux_context_t"/>
+        <associate own="org.freedesktop.BlahBlahBlah"
+         context="foo_t"/>
+  </selinux>
+
+</busconfig>

--- a/tests/data/valid-config-files/basic.d/basic.conf
+++ b/tests/data/valid-config-files/basic.d/basic.conf
@@ -1,0 +1,13 @@
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+  <user>mybususer</user>
+  <listen>unix:path=/foo/bar</listen>
+  <listen>tcp:port=1234</listen>
+  <includedir>basic.d</includedir>
+  <servicedir>/usr/share/foo</servicedir>
+  <include ignore_missing="yes">nonexistent.conf</include>
+  <policy context="default">
+    <allow user="*"/>
+  </policy>
+</busconfig>

--- a/tests/data/valid-config-files/check-own-rules.conf
+++ b/tests/data/valid-config-files/check-own-rules.conf
@@ -1,0 +1,14 @@
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+  <user>mybususer</user>
+  <listen>unix:path=/foo/bar</listen>
+  <listen>tcp:port=1234</listen>
+  <servicedir>/usr/share/foo</servicedir>
+  <policy context="default">
+    <allow user="*"/>
+    <deny own="*"/>
+    <allow own_prefix="org.freedesktop.ManySystems"/>
+  </policy>
+
+</busconfig>

--- a/tests/data/valid-config-files/entities.conf
+++ b/tests/data/valid-config-files/entities.conf
@@ -1,0 +1,14 @@
+<!-- This config file contains XML entities -->
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+  <user>mybususer</user>
+  <listen>unix:path=/foo/&lt;bar&gt;</listen>
+  <listen>tcp:port=1234</listen>
+  <includedir>basic.&#100;</includedir>
+  <servicedir>/usr/&amp;share/foo</servicedir>
+  <include ignore_missing="ye&#115;">nonexistent.conf&#110;</include>
+  <policy context="&#100;efault">
+    <allow user="*"/>
+  </policy>
+</busconfig>

--- a/tests/data/valid-config-files/listen-unix-runtime.conf
+++ b/tests/data/valid-config-files/listen-unix-runtime.conf
@@ -1,0 +1,11 @@
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-Bus Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+  <type>session</type>
+  <listen>unix:runtime=yes</listen>
+  <policy context="default">
+    <allow send_destination="*" eavesdrop="true"/>
+    <allow eavesdrop="true"/>
+    <allow own="*"/>
+  </policy>
+</busconfig>

--- a/tests/data/valid-config-files/many-rules.conf
+++ b/tests/data/valid-config-files/many-rules.conf
@@ -1,0 +1,57 @@
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+  <user>mybususer</user>
+  <listen>unix:path=/foo/bar</listen>
+  <listen>tcp:port=1234</listen>
+  <includedir>basic.d</includedir>
+  <standard_session_servicedirs />
+  <servicedir>/usr/share/foo</servicedir>
+  <include ignore_missing="yes">nonexistent.conf</include>
+  <policy context="default">
+    <allow user="*"/>
+    <deny send_interface="org.freedesktop.System" send_member="Reboot"/> 
+    <deny receive_interface="org.freedesktop.System" receive_member="Reboot"/>
+    <deny send_path="/foo/bar/SystemObjectThing" send_member="Reboot"/> 
+    <deny own="org.freedesktop.System"/>
+    <deny own_prefix="org.freedesktop.ManySystems"/>
+    <deny send_destination="org.freedesktop.System"/>
+    <deny receive_sender="org.freedesktop.System"/>
+    <allow send_type="error"/>
+    <allow send_type="method_call"/>
+    <allow send_type="method_return"/>
+    <allow send_type="signal"/>
+    <deny send_destination="org.freedesktop.Bar" send_interface="org.freedesktop.Foo"/>
+    <deny send_destination="org.freedesktop.Bar" send_interface="org.freedesktop.Foo" send_type="method_call"/>
+  </policy>
+
+  <policy context="mandatory">
+    <allow user="*"/>
+    <deny send_interface="org.freedesktop.System" send_member="Reboot"/> 
+    <deny receive_interface="org.freedesktop.System" receive_member="Reboot"/>
+    <deny send_path="/foo/bar/SystemObjectThing" send_member="Reboot"/> 
+    <deny own="org.freedesktop.System"/>
+    <deny own_prefix="org.freedesktop.ManySystems"/>
+    <deny send_destination="org.freedesktop.System"/>
+    <deny receive_sender="org.freedesktop.System"/>
+    <allow send_type="error"/>
+    <allow send_type="method_call"/>
+    <allow send_type="method_return"/>
+    <allow send_type="signal"/>
+    <deny send_destination="org.freedesktop.Bar" send_interface="org.freedesktop.Foo"/>
+    <deny send_destination="org.freedesktop.Bar" send_interface="org.freedesktop.Foo" send_type="method_call"/>
+  </policy>
+
+  <limit name="max_incoming_bytes">5000</limit>   
+  <limit name="max_outgoing_bytes">5000</limit>
+  <limit name="max_message_size">300</limit>
+  <limit name="service_start_timeout">5000</limit>
+  <limit name="auth_timeout">6000</limit>
+  <limit name="max_completed_connections">50</limit>  
+  <limit name="max_incomplete_connections">80</limit>
+  <limit name="max_connections_per_user">64</limit>
+  <limit name="max_pending_service_starts">64</limit>
+  <limit name="max_names_per_connection">256</limit>
+  <limit name="max_match_rules_per_connection">512</limit>
+                                   
+</busconfig>

--- a/tests/data/valid-config-files/minimal.conf
+++ b/tests/data/valid-config-files/minimal.conf
@@ -1,0 +1,3 @@
+<busconfig>
+  <listen>tcp:port=1234</listen>
+</busconfig>

--- a/tests/data/valid-config-files/session.conf
+++ b/tests/data/valid-config-files/session.conf
@@ -1,0 +1,80 @@
+<!-- This configuration file controls the per-user-login-session message bus.
+     Add a session-local.conf and edit that rather than changing this 
+     file directly. -->
+
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-Bus Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+  <!-- Our well-known bus type, don't change this -->
+  <type>session</type>
+
+  <!-- If we fork, keep the user's original umask to avoid affecting
+       the behavior of child processes. -->
+  <keep_umask/>
+
+  <listen>tcp:host=localhost</listen>
+
+  <!-- On Unix systems, the most secure authentication mechanism is
+  EXTERNAL, which uses credential-passing over Unix sockets.
+
+  This authentication mechanism is not available on Windows,
+  is not suitable for use with the tcp: or nonce-tcp: transports,
+  and will not work on obscure flavours of Unix that do not have
+  a supported credentials-passing mechanism. On those platforms/transports,
+  comment out the <auth> element to allow fallback to DBUS_COOKIE_SHA1. -->
+  <!--<auth>EXTERNAL</auth>-->
+
+  <standard_session_servicedirs />
+
+  <policy context="default">
+    <!-- Allow everything to be sent -->
+    <allow send_destination="*" eavesdrop="true"/>
+    <!-- Allow everything to be received -->
+    <allow eavesdrop="true"/>
+    <!-- Allow anyone to own anything -->
+    <allow own="*"/>
+  </policy>
+
+  <!-- Include legacy configuration location -->
+  <include ignore_missing="yes">../../etc/dbus-1/session.conf</include>
+
+  <!-- Config files are placed here that among other things, 
+       further restrict the above policy for specific services. -->
+  <includedir>session.d</includedir>
+
+  <includedir>../../etc/dbus-1/session.d</includedir>
+
+  <!-- This is included last so local configuration can override what's 
+       in this standard file -->
+  <include ignore_missing="yes">../../etc/dbus-1/session-local.conf</include>
+
+  <include if_selinux_enabled="yes" selinux_root_relative="yes">contexts/dbus_contexts</include>
+
+  <!-- For the session bus, override the default relatively-low limits 
+       with essentially infinite limits, since the bus is just running 
+       as the user anyway, using up bus resources is not something we need 
+       to worry about. In some cases, we do set the limits lower than 
+       "all available memory" if exceeding the limit is almost certainly a bug, 
+       having the bus enforce a limit is nicer than a huge memory leak. But the 
+       intent is that these limits should never be hit. -->
+
+  <!-- the memory limits are 1G instead of say 4G because they can't exceed 32-bit signed int max -->
+  <limit name="max_incoming_bytes">1000000000</limit>
+  <limit name="max_incoming_unix_fds">250000000</limit>
+  <limit name="max_outgoing_bytes">1000000000</limit>
+  <limit name="max_outgoing_unix_fds">250000000</limit>
+  <limit name="max_message_size">1000000000</limit>
+  <!-- We do not override max_message_unix_fds here since the in-kernel
+       limit is also relatively low -->
+  <limit name="service_start_timeout">120000</limit>  
+  <limit name="auth_timeout">240000</limit>
+  <limit name="pending_fd_timeout">150000</limit>
+  <limit name="max_completed_connections">100000</limit>  
+  <limit name="max_incomplete_connections">10000</limit>
+  <limit name="max_connections_per_user">100000</limit>
+  <limit name="max_pending_service_starts">10000</limit>
+  <limit name="max_names_per_connection">50000</limit>
+  <limit name="max_match_rules_per_connection">50000</limit>
+  <limit name="max_replies_per_connection">50000</limit>
+
+</busconfig>

--- a/tests/data/valid-config-files/standard-session-dirs.conf
+++ b/tests/data/valid-config-files/standard-session-dirs.conf
@@ -1,0 +1,8 @@
+<!-- Simplified version of session.conf -->
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-Bus Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+  <listen>unix:path=/foo</listen>
+  <type>session</type>
+  <standard_session_servicedirs />
+</busconfig>

--- a/tests/fdo.rs
+++ b/tests/fdo.rs
@@ -38,9 +38,7 @@ async fn name_ownership_changes() {
 }
 
 async fn name_ownership_changes_(address: &str, auth_mechanism: AuthMechanism) {
-    let mut bus = Bus::for_address(Some(address), auth_mechanism)
-        .await
-        .unwrap();
+    let mut bus = Bus::for_address(address, auth_mechanism).await.unwrap();
     let (tx, rx) = tokio::sync::oneshot::channel();
 
     let handle = tokio::spawn(async move {

--- a/tests/greet.rs
+++ b/tests/greet.rs
@@ -40,9 +40,7 @@ async fn greet() {
 }
 
 async fn greet_(socket_addr: &str, auth_mechanism: AuthMechanism) {
-    let mut bus = Bus::for_address(Some(socket_addr), auth_mechanism)
-        .await
-        .unwrap();
+    let mut bus = Bus::for_address(socket_addr, auth_mechanism).await.unwrap();
     let (tx, mut rx) = channel(1);
 
     let handle = tokio::spawn(async move {

--- a/tests/multiple_conns.rs
+++ b/tests/multiple_conns.rs
@@ -32,9 +32,7 @@ async fn multi_conenct() {
 }
 
 async fn multi_conenct_(socket_addr: &str, auth_mechanism: AuthMechanism) {
-    let mut bus = Bus::for_address(Some(socket_addr), auth_mechanism)
-        .await
-        .unwrap();
+    let mut bus = Bus::for_address(socket_addr, auth_mechanism).await.unwrap();
     let (tx, rx) = channel();
 
     let handle = tokio::spawn(async move {


### PR DESCRIPTION
This series allows to run busd against dbus-broker benchmark, with:
```
DBUS_BROKER_TEST_DAEMON=path-to-busd/target/debug/busd dbus-broker/build/test/dbus/bench-connect
```
The most important change is the introduction of `<busconfig>` parsing, and then handling of a few command line options.

The test currently hangs after what looks like an initial successful connection. Further investigation needed.

/!\ This branch needs https://github.com/dbus2/zbus/pull/390