### PR TITLE
🚨 Explicit lifetimes for constant string literals

### DIFF
--- a/src/fdo/dbus.rs
+++ b/src/fdo/dbus.rs
@@ -26,8 +26,8 @@ pub struct DBus {
 }
 
 impl DBus {
-    pub const PATH: &str = "/org/freedesktop/DBus";
-    pub const INTERFACE: &str = "org.freedesktop.DBus";
+    pub const PATH: &'static str = "/org/freedesktop/DBus";
+    pub const INTERFACE: &'static str = "org.freedesktop.DBus";
 
     pub fn new(peers: Arc<Peers>, guid: Arc<Guid>) -> Self {
         Self {

--- a/src/fdo/monitoring.rs
+++ b/src/fdo/monitoring.rs
@@ -18,8 +18,8 @@ pub struct Monitoring {
 }
 
 impl Monitoring {
-    pub const PATH: &str = "/org/freedesktop/DBus";
-    pub const INTERFACE: &str = "org.freedesktop.DBus.Monitoring";
+    pub const PATH: &'static str = "/org/freedesktop/DBus";
+    pub const INTERFACE: &'static str = "org.freedesktop.DBus.Monitoring";
 
     pub fn new(peers: Arc<Peers>) -> Self {
         Self {


### PR DESCRIPTION
```
warning: `&` without an explicit lifetime name cannot be used here
  --> src/fdo/dbus.rs:29:21
   |
29 |     pub const PATH: &str = "/org/freedesktop/DBus";
   |                     ^
   |
   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
   = note: for more information, see issue #115010 <https://github.com/rust-lang/rust/issues/115010>
   = note: `#[warn(elided_lifetimes_in_associated_constant)]` on by default
help: use the `'static` lifetime
   |
29 |     pub const PATH: &'static str = "/org/freedesktop/DBus";
   |                      +++++++
```