### PR TITLE
🤖 Fix renovate file

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,9 +12,7 @@
     },
     {
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-      "automerge": true
-    },
-    {
+      "automerge": true,
       "rebaseWhen": "conflicted"
     }
   ]


### PR DESCRIPTION
```
Error type: The renovate configuration file contains some invalid settings
Message: packageRules[3]: Each packageRule must contain at least one match* or exclude* selector. Rule: {"rebaseWhen":"conflicted"}
```