### PR TITLE
⏪️ Revert "👷 CI: Tell clippy to also lint tests"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,4 +65,4 @@ jobs:
           components: clippy
       - uses: Swatinem/rust-cache@v2
       - name: Check common mistakes
-        run: cargo clippy --tests --all -- -D warnings
+        run: cargo clippy --all -- -D warnings


### PR DESCRIPTION
This reverts commit ece49d965d7389544fafcd8721807a5e6520bc42.

This turns out to be a bad idea: https://github.com/dbus2/busd/actions/runs/8177258949/job/22398322387