### PR TITLE
🔥 Don't print GUID in the address

### DIFF
--- a/src/bin/busd.rs
+++ b/src/bin/busd.rs
@@ -84,7 +84,7 @@ async fn main() -> Result<()> {
     }
 
     if args.print_address {
-        println!("{},guid={}", bus.address(), bus.guid());
+        println!("{}", bus.address());
     }
 
     // FIXME: How to handle this gracefully on Windows?


### PR DESCRIPTION
zbus 4 now includes the GUID in the address's string representation. Without this change, zbus (and probably other libraries) will fail to parse the address.