### PR TITLE
🛂 Drop auth-mechanism CLI arg

### DIFF
--- a/tests/fdo.rs
+++ b/tests/fdo.rs
@@ -15,7 +15,7 @@ use tracing::instrument;
 use zbus::{
     fdo::{self, DBusProxy, ReleaseNameReply, RequestNameFlags, RequestNameReply},
     names::{BusName, WellKnownName},
-    AuthMechanism, CacheProperties, ConnectionBuilder,
+    CacheProperties, ConnectionBuilder,
 };
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -30,18 +30,16 @@ async fn name_ownership_changes() {
         let s = Alphanumeric.sample_string(&mut thread_rng(), 10);
         let path = temp_dir().join(s);
         let address = format!("unix:path={}", path.display());
-        name_ownership_changes_(&address, AuthMechanism::External).await;
+        name_ownership_changes_(&address).await;
     }
 
     // TCP socket
     let address = "tcp:host=127.0.0.1,port=4242".to_string();
-    name_ownership_changes_(&address, AuthMechanism::Anonymous).await;
+    name_ownership_changes_(&address).await;
 }
 
-async fn name_ownership_changes_(address: &str, auth_mechanism: AuthMechanism) {
-    let mut bus = Bus::for_address(Some(address), auth_mechanism)
-        .await
-        .unwrap();
+async fn name_ownership_changes_(address: &str) {
+    let mut bus = Bus::for_address(Some(address)).await.unwrap();
     let (tx, rx) = tokio::sync::oneshot::channel();
 
     let handle = tokio::spawn(async move {

--- a/tests/greet.rs
+++ b/tests/greet.rs
@@ -17,8 +17,8 @@ use zbus::{
     fdo::{self, DBusProxy},
     interface, proxy,
     zvariant::ObjectPath,
-    AsyncDrop, AuthMechanism, CacheProperties, Connection, ConnectionBuilder, MatchRule,
-    MessageHeader, MessageStream, SignalContext,
+    AsyncDrop, CacheProperties, Connection, ConnectionBuilder, MatchRule, MessageHeader,
+    MessageStream, SignalContext,
 };
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -33,18 +33,16 @@ async fn greet() {
         let s = Alphanumeric.sample_string(&mut thread_rng(), 10);
         let path = temp_dir().join(s);
         let address = format!("unix:path={}", path.display());
-        greet_(&address, AuthMechanism::External).await;
+        greet_(&address).await;
     }
 
     // TCP socket
     let address = "tcp:host=127.0.0.1,port=4248".to_string();
-    greet_(&address, AuthMechanism::Anonymous).await;
+    greet_(&address).await;
 }
 
-async fn greet_(socket_addr: &str, auth_mechanism: AuthMechanism) {
-    let mut bus = Bus::for_address(Some(socket_addr), auth_mechanism)
-        .await
-        .unwrap();
+async fn greet_(socket_addr: &str) {
+    let mut bus = Bus::for_address(Some(socket_addr)).await.unwrap();
     let (tx, mut rx) = channel(1);
 
     let handle = tokio::spawn(async move {

--- a/tests/monitor.rs
+++ b/tests/monitor.rs
@@ -7,7 +7,7 @@ use tracing::instrument;
 use zbus::{
     fdo::{DBusProxy, MonitoringProxy, NameAcquired, NameLost, NameOwnerChanged, RequestNameFlags},
     names::BusName,
-    AuthMechanism, CacheProperties, ConnectionBuilder, MessageStream, MessageType,
+    CacheProperties, ConnectionBuilder, MessageStream, MessageType,
 };
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -17,9 +17,7 @@ async fn become_monitor() {
     busd::tracing_subscriber::init();
 
     let address = "tcp:host=127.0.0.1,port=4242".to_string();
-    let mut bus = Bus::for_address(Some(&address), AuthMechanism::Anonymous)
-        .await
-        .unwrap();
+    let mut bus = Bus::for_address(Some(&address)).await.unwrap();
     let (tx, rx) = tokio::sync::oneshot::channel();
 
     let handle = tokio::spawn(async move {

--- a/tests/multiple_conns.rs
+++ b/tests/multiple_conns.rs
@@ -11,7 +11,7 @@ use rand::{
 };
 use tokio::{select, sync::oneshot::channel};
 use tracing::instrument;
-use zbus::{AuthMechanism, ConnectionBuilder};
+use zbus::ConnectionBuilder;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 #[instrument]
@@ -24,18 +24,16 @@ async fn multi_conenct() {
         let s = Alphanumeric.sample_string(&mut thread_rng(), 10);
         let path = temp_dir().join(s);
         let address = format!("unix:path={}", path.display());
-        multi_conenct_(&address, AuthMechanism::External).await;
+        multi_conenct_(&address).await;
     }
 
     // TCP socket
     let address = "tcp:host=127.0.0.1,port=4246".to_string();
-    multi_conenct_(&address, AuthMechanism::Anonymous).await;
+    multi_conenct_(&address).await;
 }
 
-async fn multi_conenct_(socket_addr: &str, auth_mechanism: AuthMechanism) {
-    let mut bus = Bus::for_address(Some(socket_addr), auth_mechanism)
-        .await
-        .unwrap();
+async fn multi_conenct_(socket_addr: &str) {
+    let mut bus = Bus::for_address(Some(socket_addr)).await.unwrap();
     let (tx, rx) = channel();
 
     let handle = tokio::spawn(async move {


### PR DESCRIPTION
It's now automatically chosen for you, based on the socket type in use. For UNIX sockets and for TCP on Windows, we use `EXTERNAL`. For TCP sockets on non-Windows, we use `ANONYMOUS` (i-e no authentication at all).

On Unix machines, people should use the UNIX socket anyway and if EXTERNAL is possible, it's best to stick to it. `dbus-broker` also doesn't support anonymous authentication and since they only support Unix sockets for transport, it means they don't support anonymous authentication at all.