### PR TITLE
feat: initial work on supporting dbus-daemon XML configuration files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -362,6 +362,7 @@ dependencies = [
  "hex",
  "nix",
  "ntest",
+ "quick-xml",
  "rand",
  "serde",
  "tokio",
@@ -1282,6 +1283,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cee5168b05f49d4b0ca581206eb14a7b22fafd963efe729ac48eb03266e25cc2"
 dependencies = [
  "prost",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.36.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ tracing-subscriber = { version = "0.3.18", features = [
     "ansi",
 ], default-features = false, optional = true }
 anyhow = "1.0.82"
+quick-xml = { version = "0.36.2", features = ["overlapped-lists", "serialize"] }
 # Explicitly depend on serde to enable `rc` feature.
 serde = { version = "1.0.200", features = ["rc"] }
 futures-util = "0.3.30"

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -1,0 +1,588 @@
+//! implementation of "Configuration File" described at:
+//! https://dbus.freedesktop.org/doc/dbus-daemon.1.html
+
+use std::{path::PathBuf, str::FromStr};
+
+use serde::Deserialize;
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+struct Apparmor {
+    #[serde(rename = "@mode")]
+    mode: Option<ApparmorMode>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+enum ApparmorMode {
+    Disabled,
+    Enabled,
+    Required,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+struct Associate {
+    #[serde(rename = "@context")]
+    context: String,
+    #[serde(rename = "@own")]
+    own: String,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct Configuration {
+    allow_anonymous: Option<bool>,
+    apparmor: Option<ApparmorMode>,
+    auth: Vec<String>,
+    fork: Option<bool>,
+    include: Vec<IncludeElement>,
+    includedir: Vec<PathBufElement>,
+    keep_umask: Option<bool>,
+    limit: Vec<LimitElement>,
+    listen: Vec<String>,
+    pidfile: Option<PathBuf>,
+    policy: Vec<Policy>,
+    selinux: Vec<Associate>,
+    servicedir: Vec<PathBufElement>,
+    servicehelper: Option<PathBuf>,
+    standard_session_servicedirs: Option<bool>,
+    standard_system_servicedirs: Option<bool>,
+    syslog: Option<bool>,
+    r#type: Option<Type>,
+    user: Option<Principal>,
+}
+impl TryFrom<RawConfiguration> for Configuration {
+    type Error = Error;
+
+    fn try_from(value: RawConfiguration) -> Result<Self, Self::Error> {
+        let mut policy = Vec::with_capacity(value.policy.len());
+        for rp in value.policy {
+            match Policy::try_from(rp) {
+                Ok(p) => policy.push(p),
+                Err(err) => {
+                    return Err(err);
+                }
+            }
+        }
+
+        let mut bc = Self {
+            allow_anonymous: value.allow_anonymous.map(|_| true),
+            apparmor: match value.apparmor {
+                Some(a) => a.mode,
+                None => None,
+            },
+            auth: value.auth,
+            fork: value.fork.map(|_| true),
+            include: value.include,
+            includedir: value.includedir,
+            keep_umask: value.keep_umask.map(|_| true),
+            limit: value.limit,
+            listen: value.listen,
+            pidfile: value.pidfile,
+            policy,
+            // TODO: SELinux could probably more-conveniently be represented as a HashMap
+            // TODO: last one wins for SELinux associates with the same name
+            selinux: match value.selinux {
+                Some(s) => s.associate,
+                None => vec![],
+            },
+            servicedir: value.servicedir,
+            servicehelper: value.servicehelper,
+            standard_session_servicedirs: value.standard_session_servicedirs.map(|_| true),
+            standard_system_servicedirs: value.standard_system_servicedirs.map(|_| true),
+            syslog: value.syslog.map(|_| true),
+            ..Default::default()
+        };
+
+        // > The last element "wins"
+        if let Some(te) = value.r#type.into_iter().last() {
+            bc.r#type = Some(te.text);
+        }
+        if let Some(ue) = value.user.into_iter().last() {
+            bc.user = Some(ue.text);
+        }
+
+        Ok(bc)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum Error {
+    PolicyHasMultipleAttributes,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+enum IgnoreMissing {
+    No,
+    Yes,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+enum Include {
+    Session,
+    System,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+struct IncludeElement {
+    #[serde(rename = "@ignore_missing")]
+    ignore_missing: Option<IgnoreMissing>,
+    #[serde(rename = "$text")]
+    text: PathBuf,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+struct LimitElement {
+    #[serde(rename = "@name")]
+    name: LimitName,
+    #[serde(rename = "$text")]
+    text: i32, // semantically should be u32, but i32 for compatibility
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+enum LimitName {
+    AuthTimeout,
+    MaxCompletedConnections,
+    MaxConnectionsPerUser,
+    MaxIncomingBytes,
+    MaxIncomingUnixFds,
+    MaxIncompleteConnections,
+    MaxMatchRulesPerConnection,
+    MaxMessageSize,
+    MaxMessageUnixFds,
+    MaxNamesPerConnection,
+    MaxOutgoingBytes,
+    MaxOutgoingUnixFds,
+    MaxPendingServiceStarts,
+    MaxRepliesPerConnection,
+    PendingFdTimeout,
+    ServiceStartTimeout,
+    ReplyTimeout,
+}
+
+// reuse this between Vec<PathBuf> fields,
+// except those with field-specific attributes
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+struct PathBufElement {
+    #[serde(rename = "$text")]
+    text: PathBuf,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+enum Policy {
+    Console { rules: Vec<Rule> },
+    DefaultContext { rules: Vec<Rule> },
+    Group { group: Principal, rules: Vec<Rule> },
+    MandatoryContext { rules: Vec<Rule> },
+    NoConsole { rules: Vec<Rule> },
+    User { user: Principal, rules: Vec<Rule> },
+}
+impl TryFrom<RawPolicy> for Policy {
+    type Error = Error;
+    fn try_from(value: RawPolicy) -> Result<Self, Self::Error> {
+        // TODO: more validations and conversions as documented against dbus-daemon
+        match value {
+            RawPolicy {
+                at_console: Some(b),
+                context: None,
+                group: None,
+                rules,
+                user: None,
+            } => Ok(match b {
+                true => Self::Console { rules },
+                false => Self::NoConsole { rules },
+            }),
+            RawPolicy {
+                at_console: None,
+                context: Some(pc),
+                group: None,
+                rules,
+                user: None,
+            } => Ok(match pc {
+                PolicyContext::Default => Self::DefaultContext { rules },
+                PolicyContext::Mandatory => Self::MandatoryContext { rules },
+            }),
+            RawPolicy {
+                at_console: None,
+                context: None,
+                group: Some(p),
+                rules,
+                user: None,
+            } => Ok(Self::Group { group: p, rules }),
+            RawPolicy {
+                at_console: None,
+                context: None,
+                group: None,
+                rules,
+                user: Some(p),
+            } => Ok(Self::User { user: p, rules }),
+            _ => Err(Error::PolicyHasMultipleAttributes),
+        }
+    }
+}
+// TODO: impl PartialOrd/Ord for Policy, for order in which policies are applied to a connection
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+enum PolicyContext {
+    Default,
+    Mandatory,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+#[serde(default)]
+struct PolicyList {
+    policy: Vec<RawPolicy>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase", untagged)]
+enum Principal {
+    Id(u32),
+    Name(String),
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct RawConfiguration {
+    allow_anonymous: Option<()>,
+    apparmor: Option<Apparmor>,
+    auth: Vec<String>,
+    fork: Option<()>,
+    include: Vec<IncludeElement>,
+    includedir: Vec<PathBufElement>,
+    keep_umask: Option<()>,
+    limit: Vec<LimitElement>,
+    listen: Vec<String>,
+    pidfile: Option<PathBuf>,
+    policy: Vec<RawPolicy>,
+    selinux: Option<Selinux>,
+    servicedir: Vec<PathBufElement>,
+    servicehelper: Option<PathBuf>,
+    standard_session_servicedirs: Option<()>,
+    standard_system_servicedirs: Option<()>,
+    syslog: Option<()>,
+    r#type: Vec<TypeElement>,
+    user: Vec<UserElement>,
+}
+impl FromStr for RawConfiguration {
+    type Err = quick_xml::DeError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // TODO: validate expected DOCTYPE
+        // TODO: validate expected root element (busconfig)
+        quick_xml::de::from_str(s)
+    }
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+struct RawPolicy {
+    #[serde(rename = "@at_console")]
+    at_console: Option<bool>,
+    #[serde(rename = "@context")]
+    context: Option<PolicyContext>,
+    #[serde(rename = "@group")]
+    group: Option<Principal>,
+    #[serde(default, rename = "$value")]
+    rules: Vec<Rule>,
+    #[serde(rename = "@user")]
+    user: Option<Principal>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+enum Rule {
+    Allow(RuleAttributes),
+    Deny(RuleAttributes),
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+#[serde(default, rename_all = "lowercase")]
+struct RuleAttributes {
+    #[serde(rename = "@send_interface")]
+    send_interface: Option<RuleMatch>,
+    #[serde(rename = "@send_member")]
+    send_member: Option<RuleMatch>,
+    #[serde(rename = "@send_error")]
+    send_error: Option<RuleMatch>,
+    #[serde(rename = "@send_broadcast")]
+    send_broadcast: Option<bool>,
+    #[serde(rename = "@send_destination")]
+    send_destination: Option<RuleMatch>,
+    #[serde(rename = "@send_destination_prefix")]
+    send_destination_prefix: Option<String>,
+    #[serde(rename = "@send_type")]
+    send_type: Option<RuleMatchType>,
+    #[serde(rename = "@send_path")]
+    send_path: Option<RuleMatch>,
+    #[serde(rename = "@receive_interface")]
+    receive_interface: Option<RuleMatch>,
+    #[serde(rename = "@receive_member")]
+    receive_member: Option<RuleMatch>,
+    #[serde(rename = "@receive_error")]
+    receive_error: Option<RuleMatch>,
+    #[serde(rename = "@receive_sender")]
+    receive_sender: Option<RuleMatch>,
+    #[serde(rename = "@receive_type")]
+    receive_type: Option<RuleMatchType>,
+    #[serde(rename = "@receive_path")]
+    receive_path: Option<RuleMatch>,
+    #[serde(rename = "@send_requested_reply")]
+    send_requested_reply: Option<bool>,
+    #[serde(rename = "@receive_requested_reply")]
+    receive_requested_reply: Option<bool>,
+    #[serde(rename = "@eavesdrop")]
+    eavesdrop: Option<bool>,
+    #[serde(rename = "@own")]
+    own: Option<RuleMatch>,
+    #[serde(rename = "@own_prefix")]
+    own_prefix: Option<String>,
+    #[serde(rename = "@user")]
+    user: Option<RuleMatch>,
+    #[serde(rename = "@group")]
+    group: Option<RuleMatch>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case", untagged)]
+enum RuleMatch {
+    #[serde(rename = "*")]
+    Any,
+    One(String),
+}
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+enum RuleMatchType {
+    #[serde(rename = "*")]
+    Any,
+    Error,
+    MethodCall,
+    MethodReturn,
+    Signal,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+#[serde(default)]
+struct Selinux {
+    associate: Vec<Associate>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+enum Type {
+    Session,
+    System,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+struct TypeElement {
+    #[serde(rename = "$text")]
+    text: Type,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+struct UserElement {
+    #[serde(rename = "$text")]
+    text: Principal,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn busconfig_fromstr_last_type_wins_ok() {
+        let input = r#"
+                <!DOCTYPE busconfig PUBLIC
+     "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+     "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+    <busconfig>
+        <type>system</type>
+        <type>session</type>
+    </busconfig>
+            "#;
+
+        let got = RawConfiguration::from_str(input).expect("should parse input XML");
+        let got = Configuration::try_from(got).expect("should validate and convert");
+
+        assert_eq!(got.r#type, Some(Type::Session));
+    }
+
+    #[test]
+    fn busconfig_fromstr_last_user_wins_ok() {
+        let input = r#"
+                <!DOCTYPE busconfig PUBLIC
+     "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+     "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+    <busconfig>
+        <user>1234</user>
+        <user>nobody</user>
+    </busconfig>
+            "#;
+
+        let got = RawConfiguration::from_str(input).expect("should parse input XML");
+        let got = Configuration::try_from(got).expect("should validate and convert");
+
+        assert_eq!(got.user, Some(Principal::Name(String::from("nobody"))));
+    }
+
+    #[test]
+    fn busconfig_fromstr_allow_deny_allow_ok() {
+        // from https://github.com/OpenPrinting/system-config-printer/blob/caa1ba33da20fd2a82cee0bcc97589fede512cc8/dbus/com.redhat.PrinterDriversInstaller.conf
+        // selected because it has a <deny /> in the middle of a list of <allow />s
+        let input = r#"
+            <!DOCTYPE busconfig PUBLIC
+ "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+	<policy user="root">
+		<allow send_destination="com.redhat.PrinterDriversInstaller"
+		       send_interface="com.redhat.PrinterDriversInstaller"/>
+	</policy>
+
+	<policy context="default">
+		<allow own="com.redhat.PrinterDriversInstaller"/>
+
+		<deny send_destination="com.redhat.PrinterDriversInstaller"
+		      send_interface="com.redhat.PrinterDriversInstaller"/>
+		<allow send_destination="com.redhat.PrinterDriversInstaller"
+		       send_interface="org.freedesktop.DBus.Introspectable" />
+		<allow send_destination="com.redhat.PrinterDriversInstaller"
+		       send_interface="org.freedesktop.DBus.Properties" />
+	</policy>
+</busconfig>
+        "#;
+
+        let got = RawConfiguration::from_str(input).expect("should parse input XML");
+        let got = Configuration::try_from(got).expect("should validate and convert");
+
+        assert_eq!(
+            got,
+            Configuration {
+                policy: vec![
+                    Policy::User {
+                        rules: vec![Rule::Allow(RuleAttributes {
+                            send_destination: Some(RuleMatch::One(String::from(
+                                "com.redhat.PrinterDriversInstaller"
+                            ))),
+                            send_interface: Some(RuleMatch::One(String::from(
+                                "com.redhat.PrinterDriversInstaller"
+                            ))),
+                            ..Default::default()
+                        })],
+                        user: Principal::Name(String::from("root")),
+                    },
+                    Policy::DefaultContext {
+                        rules: vec![
+                            Rule::Allow(RuleAttributes {
+                                own: Some(RuleMatch::One(String::from(
+                                    "com.redhat.PrinterDriversInstaller"
+                                ))),
+                                ..Default::default()
+                            }),
+                            Rule::Deny(RuleAttributes {
+                                send_destination: Some(RuleMatch::One(String::from(
+                                    "com.redhat.PrinterDriversInstaller"
+                                ))),
+                                send_interface: Some(RuleMatch::One(String::from(
+                                    "com.redhat.PrinterDriversInstaller"
+                                ))),
+                                ..Default::default()
+                            }),
+                            Rule::Allow(RuleAttributes {
+                                send_destination: Some(RuleMatch::One(String::from(
+                                    "com.redhat.PrinterDriversInstaller"
+                                ))),
+                                send_interface: Some(RuleMatch::One(String::from(
+                                    "org.freedesktop.DBus.Introspectable"
+                                ))),
+                                ..Default::default()
+                            }),
+                            Rule::Allow(RuleAttributes {
+                                send_destination: Some(RuleMatch::One(String::from(
+                                    "com.redhat.PrinterDriversInstaller"
+                                ))),
+                                send_interface: Some(RuleMatch::One(String::from(
+                                    "org.freedesktop.DBus.Properties"
+                                ))),
+                                ..Default::default()
+                            }),
+                        ]
+                    }
+                ],
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn busconfig_fromstr_limit_ok() {
+        let input = r#"
+            <!DOCTYPE busconfig PUBLIC
+ "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+     <limit name="max_incoming_bytes">133169152</limit>
+     <limit name="max_incoming_unix_fds">64</limit>
+</busconfig>
+        "#;
+
+        let got = RawConfiguration::from_str(input).expect("should parse input XML");
+        let got = Configuration::try_from(got).expect("should validate and convert");
+
+        assert_eq!(
+            got,
+            Configuration {
+                limit: vec![
+                    LimitElement {
+                        name: LimitName::MaxIncomingBytes,
+                        text: 133169152
+                    },
+                    LimitElement {
+                        name: LimitName::MaxIncomingUnixFds,
+                        text: 64
+                    },
+                ],
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn busconfig_fromstr_apparmor_and_selinux_ok() {
+        let input = r#"
+            <!DOCTYPE busconfig PUBLIC
+ "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+    <apparmor mode="enabled" />
+    <selinux>
+        <associate own="org.freedesktop.Foobar" context="foo_t" />
+    </selinux>
+</busconfig>
+        "#;
+
+        let got = RawConfiguration::from_str(input).expect("should parse input XML");
+        let got = Configuration::try_from(got).expect("should validate and convert");
+
+        assert_eq!(
+            got,
+            Configuration {
+                apparmor: Some(ApparmorMode::Enabled),
+                selinux: vec![Associate {
+                    context: String::from("foo_t"),
+                    own: String::from("org.freedesktop.Foobar")
+                },],
+                ..Default::default()
+            }
+        );
+    }
+}

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -3,7 +3,10 @@
 
 use std::{path::PathBuf, str::FromStr};
 
+use raw::{RawConfiguration, RawPolicy, RawPolicyContext, RawRule, RawRuleAttributes};
 use serde::Deserialize;
+
+mod raw;
 
 #[derive(Clone, Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "lowercase")]
@@ -252,142 +255,6 @@ impl TryFrom<RawPolicy> for Policy {
 pub enum Principal {
     Id(u32),
     Name(String),
-}
-
-#[derive(Clone, Debug, Deserialize, PartialEq)]
-#[serde(rename_all = "lowercase")]
-struct RawApparmor {
-    #[serde(rename = "@mode")]
-    mode: Option<ApparmorMode>,
-}
-
-#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
-#[serde(default)]
-struct RawConfiguration {
-    allow_anonymous: Option<()>,
-    apparmor: Option<RawApparmor>,
-    auth: Vec<String>,
-    fork: Option<()>,
-    include: Vec<IncludeElement>,
-    includedir: Vec<PathBufElement>,
-    keep_umask: Option<()>,
-    limit: Vec<LimitElement>,
-    listen: Vec<String>,
-    pidfile: Option<PathBuf>,
-    policy: Vec<RawPolicy>,
-    selinux: Option<RawSelinux>,
-    servicedir: Vec<PathBufElement>,
-    servicehelper: Option<PathBuf>,
-    standard_session_servicedirs: Option<()>,
-    standard_system_servicedirs: Option<()>,
-    syslog: Option<()>,
-    r#type: Vec<RawTypeElement>,
-    user: Vec<RawUserElement>,
-}
-impl FromStr for RawConfiguration {
-    type Err = quick_xml::DeError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        // TODO: validate expected DOCTYPE
-        // TODO: validate expected root element (busconfig)
-        quick_xml::de::from_str(s)
-    }
-}
-
-#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
-#[serde(rename_all = "lowercase")]
-struct RawPolicy {
-    #[serde(rename = "@at_console")]
-    at_console: Option<bool>,
-    #[serde(rename = "@context")]
-    context: Option<RawPolicyContext>,
-    #[serde(rename = "@group")]
-    group: Option<Principal>,
-    #[serde(default, rename = "$value")]
-    rules: Vec<RawRule>,
-    #[serde(rename = "@user")]
-    user: Option<Principal>,
-}
-
-#[derive(Clone, Debug, Deserialize, PartialEq)]
-#[serde(rename_all = "lowercase")]
-enum RawPolicyContext {
-    Default,
-    Mandatory,
-}
-
-#[derive(Clone, Debug, Deserialize, PartialEq)]
-#[serde(rename_all = "lowercase")]
-enum RawRule {
-    Allow(RawRuleAttributes),
-    Deny(RawRuleAttributes),
-}
-
-#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
-#[serde(default, rename_all = "lowercase")]
-struct RawRuleAttributes {
-    #[serde(rename = "@send_interface")]
-    send_interface: Option<RuleMatch>,
-    #[serde(rename = "@send_member")]
-    send_member: Option<RuleMatch>,
-    #[serde(rename = "@send_error")]
-    send_error: Option<RuleMatch>,
-    #[serde(rename = "@send_broadcast")]
-    send_broadcast: Option<bool>,
-    #[serde(rename = "@send_destination")]
-    send_destination: Option<RuleMatch>,
-    #[serde(rename = "@send_destination_prefix")]
-    send_destination_prefix: Option<String>,
-    #[serde(rename = "@send_type")]
-    send_type: Option<RuleMatchType>,
-    #[serde(rename = "@send_path")]
-    send_path: Option<RuleMatch>,
-    #[serde(rename = "@receive_interface")]
-    receive_interface: Option<RuleMatch>,
-    #[serde(rename = "@receive_member")]
-    receive_member: Option<RuleMatch>,
-    #[serde(rename = "@receive_error")]
-    receive_error: Option<RuleMatch>,
-    #[serde(rename = "@receive_sender")]
-    receive_sender: Option<RuleMatch>,
-    #[serde(rename = "@receive_type")]
-    receive_type: Option<RuleMatchType>,
-    #[serde(rename = "@receive_path")]
-    receive_path: Option<RuleMatch>,
-    #[serde(rename = "@send_requested_reply")]
-    send_requested_reply: Option<bool>,
-    #[serde(rename = "@receive_requested_reply")]
-    receive_requested_reply: Option<bool>,
-    #[serde(rename = "@eavesdrop")]
-    eavesdrop: Option<bool>,
-    #[serde(rename = "@own")]
-    own: Option<RuleMatch>,
-    #[serde(rename = "@own_prefix")]
-    own_prefix: Option<String>,
-    #[serde(rename = "@user")]
-    user: Option<RuleMatch>,
-    #[serde(rename = "@group")]
-    group: Option<RuleMatch>,
-}
-
-#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
-#[serde(default)]
-struct RawSelinux {
-    associate: Vec<Associate>,
-}
-
-#[derive(Clone, Debug, Deserialize, PartialEq)]
-#[serde(rename_all = "lowercase")]
-struct RawTypeElement {
-    #[serde(rename = "$text")]
-    text: Type,
-}
-
-#[derive(Clone, Debug, Deserialize, PartialEq)]
-#[serde(rename_all = "lowercase")]
-struct RawUserElement {
-    #[serde(rename = "$text")]
-    text: Principal,
 }
 
 #[derive(Clone, Debug, Default, PartialEq)]

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -3,10 +3,12 @@
 
 use std::{path::PathBuf, str::FromStr};
 
-use raw::{RawConfiguration, RawPolicy, RawPolicyContext, RawRule, RawRuleAttributes};
 use serde::Deserialize;
 
+mod policy;
 mod raw;
+
+use crate::configuration::{policy::Policy, raw::RawConfiguration};
 
 #[derive(Clone, Debug, Default, Deserialize, PartialEq)]
 #[serde(rename_all = "lowercase")]
@@ -114,12 +116,6 @@ impl TryFrom<RawConfiguration> for Configuration {
     }
 }
 
-#[derive(Clone, Debug, Default, PartialEq)]
-pub struct ConnectRule {
-    group: Option<RuleMatch>,
-    user: Option<RuleMatch>,
-}
-
 #[derive(Clone, Debug)]
 pub enum Error {
     DeserializeXml(quick_xml::DeError),
@@ -174,269 +170,11 @@ pub enum LimitName {
     ReplyTimeout,
 }
 
-#[derive(Clone, Debug, Default, PartialEq)]
-pub struct OwnRule {
-    own: Option<RuleMatch>,
-    own_prefix: Option<String>,
-}
-
-#[derive(Clone, Debug, PartialEq)]
-pub enum Policy {
-    Console { rules: Vec<Rule> },
-    DefaultContext { rules: Vec<Rule> },
-    Group { group: Principal, rules: Vec<Rule> },
-    MandatoryContext { rules: Vec<Rule> },
-    NoConsole { rules: Vec<Rule> },
-    User { user: Principal, rules: Vec<Rule> },
-}
-impl TryFrom<RawPolicy> for Policy {
-    type Error = Error;
-    fn try_from(value: RawPolicy) -> Result<Self, Self::Error> {
-        let mut rules: Vec<Rule> = Vec::with_capacity(value.rules.len());
-        for rule in value.rules {
-            match Rule::try_from(rule) {
-                Ok(ok) => rules.push(ok),
-                Err(err) => return Err(err),
-            }
-        }
-
-        match value {
-            RawPolicy {
-                at_console: Some(b),
-                context: None,
-                group: None,
-                user: None,
-                ..
-            } => Ok(match b {
-                true => Self::Console { rules },
-                false => Self::NoConsole { rules },
-            }),
-            RawPolicy {
-                at_console: None,
-                context: Some(pc),
-                group: None,
-                user: None,
-                ..
-            } => Ok(match pc {
-                RawPolicyContext::Default => Self::DefaultContext { rules },
-                RawPolicyContext::Mandatory => Self::MandatoryContext { rules },
-            }),
-            RawPolicy {
-                at_console: None,
-                context: None,
-                group: Some(p),
-                user: None,
-                ..
-            } => Ok(Self::Group { group: p, rules }),
-            RawPolicy {
-                at_console: None,
-                context: None,
-                group: None,
-                user: Some(p),
-                ..
-            } => Ok(Self::User { user: p, rules }),
-            _ => Err(Error::PolicyHasMultipleAttributes),
-        }
-    }
-}
-// TODO: impl PartialOrd/Ord for Policy, for order in which policies are applied to a connection
-
 #[derive(Clone, Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "lowercase", untagged)]
 pub enum Principal {
     Id(u32),
     Name(String),
-}
-
-#[derive(Clone, Debug, Default, PartialEq)]
-pub struct ReceiveRule {
-    eavesdrop: Option<bool>,
-    receive_error: Option<RuleMatch>,
-    receive_interface: Option<RuleMatch>,
-    receive_member: Option<RuleMatch>,
-    receive_path: Option<RuleMatch>,
-    receive_requested_reply: Option<bool>,
-    receive_sender: Option<RuleMatch>,
-    receive_type: Option<RuleMatchType>,
-}
-
-pub type Rule = (RuleEffect, RulePhase);
-impl TryFrom<RawRule> for Rule {
-    type Error = Error;
-
-    fn try_from(value: RawRule) -> Result<Self, Self::Error> {
-        let (effect, attributes) = match value {
-            RawRule::Allow(attributes) => (RuleEffect::Allow, attributes),
-            RawRule::Deny(attributes) => (RuleEffect::Deny, attributes),
-        };
-        match attributes {
-            RawRuleAttributes {
-                eavesdrop,
-                group: None,
-                own: None,
-                own_prefix: None,
-                receive_error,
-                receive_interface,
-                receive_member,
-                receive_path,
-                receive_requested_reply,
-                receive_sender,
-                receive_type,
-                send_broadcast: None,
-                send_destination: None,
-                send_destination_prefix: None,
-                send_error: None,
-                send_interface: None,
-                send_member: None,
-                send_path: None,
-                send_requested_reply: None,
-                send_type: None,
-                user: None,
-            } => Ok((
-                effect,
-                RulePhase::Receive(ReceiveRule {
-                    eavesdrop,
-                    receive_error,
-                    receive_interface,
-                    receive_member,
-                    receive_path,
-                    receive_requested_reply,
-                    receive_sender,
-                    receive_type,
-                }),
-            )),
-            RawRuleAttributes {
-                eavesdrop,
-                group: None,
-                own: None,
-                own_prefix: None,
-                receive_error: None,
-                receive_interface: None,
-                receive_member: None,
-                receive_path: None,
-                receive_requested_reply: None,
-                receive_sender: None,
-                receive_type: None,
-                send_broadcast,
-                send_destination,
-                send_destination_prefix,
-                send_error,
-                send_interface,
-                send_member,
-                send_path,
-                send_requested_reply,
-                send_type,
-                user: None,
-            } => Ok((
-                effect,
-                RulePhase::Send(SendRule {
-                    eavesdrop,
-                    send_broadcast,
-                    send_destination,
-                    send_destination_prefix,
-                    send_error,
-                    send_interface,
-                    send_member,
-                    send_path,
-                    send_requested_reply,
-                    send_type,
-                }),
-            )),
-            RawRuleAttributes {
-                eavesdrop: None,
-                group: None,
-                own,
-                own_prefix,
-                receive_error: None,
-                receive_interface: None,
-                receive_member: None,
-                receive_path: None,
-                receive_requested_reply: None,
-                receive_sender: None,
-                receive_type: None,
-                send_broadcast: None,
-                send_destination: None,
-                send_destination_prefix: None,
-                send_error: None,
-                send_interface: None,
-                send_member: None,
-                send_path: None,
-                send_requested_reply: None,
-                send_type: None,
-                user: None,
-            } => Ok((effect, RulePhase::Own(OwnRule { own, own_prefix }))),
-            RawRuleAttributes {
-                eavesdrop: None,
-                group,
-                own: None,
-                own_prefix: None,
-                receive_error: None,
-                receive_interface: None,
-                receive_member: None,
-                receive_path: None,
-                receive_requested_reply: None,
-                receive_sender: None,
-                receive_type: None,
-                send_broadcast: None,
-                send_destination: None,
-                send_destination_prefix: None,
-                send_error: None,
-                send_interface: None,
-                send_member: None,
-                send_path: None,
-                send_requested_reply: None,
-                send_type: None,
-                user,
-            } => Ok((effect, RulePhase::Connect(ConnectRule { group, user }))),
-            _ => Err(Error::RuleHasInvalidCombinationOfAttributes),
-        }
-    }
-}
-
-#[derive(Clone, Debug, PartialEq)]
-pub enum RuleEffect {
-    Allow,
-    Deny,
-}
-
-#[derive(Clone, Debug, PartialEq)]
-pub enum RulePhase {
-    Connect(ConnectRule),
-    Own(OwnRule),
-    Receive(ReceiveRule),
-    Send(SendRule),
-}
-
-#[derive(Clone, Debug, Deserialize, PartialEq)]
-#[serde(rename_all = "snake_case", untagged)]
-pub enum RuleMatch {
-    #[serde(rename = "*")]
-    Any,
-    One(String),
-}
-#[derive(Clone, Debug, Deserialize, PartialEq)]
-#[serde(rename_all = "snake_case")]
-pub enum RuleMatchType {
-    #[serde(rename = "*")]
-    Any,
-    Error,
-    MethodCall,
-    MethodReturn,
-    Signal,
-}
-
-#[derive(Clone, Debug, Default, PartialEq)]
-pub struct SendRule {
-    eavesdrop: Option<bool>,
-    send_broadcast: Option<bool>,
-    send_destination: Option<RuleMatch>,
-    send_destination_prefix: Option<String>,
-    send_error: Option<RuleMatch>,
-    send_interface: Option<RuleMatch>,
-    send_member: Option<RuleMatch>,
-    send_path: Option<RuleMatch>,
-    send_requested_reply: Option<bool>,
-    send_type: Option<RuleMatchType>,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq)]
@@ -448,6 +186,10 @@ pub enum Type {
 
 #[cfg(test)]
 mod tests {
+    use crate::configuration::policy::{
+        OwnRule, ReceiveRule, RuleEffect, RuleMatch, RulePhase, SendRule,
+    };
+
     use super::*;
 
     #[test]

--- a/src/configuration/policy.rs
+++ b/src/configuration/policy.rs
@@ -1,0 +1,270 @@
+use serde::Deserialize;
+
+use super::{
+    raw::{RawPolicy, RawPolicyContext, RawRule, RawRuleAttributes},
+    Error, Principal,
+};
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct ConnectRule {
+    pub group: Option<RuleMatch>,
+    pub user: Option<RuleMatch>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct OwnRule {
+    pub own: Option<RuleMatch>,
+    pub own_prefix: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum Policy {
+    Console { rules: Vec<Rule> },
+    DefaultContext { rules: Vec<Rule> },
+    Group { group: Principal, rules: Vec<Rule> },
+    MandatoryContext { rules: Vec<Rule> },
+    NoConsole { rules: Vec<Rule> },
+    User { user: Principal, rules: Vec<Rule> },
+}
+impl TryFrom<RawPolicy> for Policy {
+    type Error = Error;
+    fn try_from(value: RawPolicy) -> Result<Self, Self::Error> {
+        let mut rules: Vec<Rule> = Vec::with_capacity(value.rules.len());
+        for rule in value.rules {
+            match Rule::try_from(rule) {
+                Ok(ok) => rules.push(ok),
+                Err(err) => return Err(err),
+            }
+        }
+
+        match value {
+            RawPolicy {
+                at_console: Some(b),
+                context: None,
+                group: None,
+                user: None,
+                ..
+            } => Ok(match b {
+                true => Self::Console { rules },
+                false => Self::NoConsole { rules },
+            }),
+            RawPolicy {
+                at_console: None,
+                context: Some(pc),
+                group: None,
+                user: None,
+                ..
+            } => Ok(match pc {
+                RawPolicyContext::Default => Self::DefaultContext { rules },
+                RawPolicyContext::Mandatory => Self::MandatoryContext { rules },
+            }),
+            RawPolicy {
+                at_console: None,
+                context: None,
+                group: Some(p),
+                user: None,
+                ..
+            } => Ok(Self::Group { group: p, rules }),
+            RawPolicy {
+                at_console: None,
+                context: None,
+                group: None,
+                user: Some(p),
+                ..
+            } => Ok(Self::User { user: p, rules }),
+            _ => Err(Error::PolicyHasMultipleAttributes),
+        }
+    }
+}
+// TODO: impl PartialOrd/Ord for Policy, for order in which policies are applied to a connection
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct ReceiveRule {
+    pub eavesdrop: Option<bool>,
+    pub receive_error: Option<RuleMatch>,
+    pub receive_interface: Option<RuleMatch>,
+    pub receive_member: Option<RuleMatch>,
+    pub receive_path: Option<RuleMatch>,
+    pub receive_requested_reply: Option<bool>,
+    pub receive_sender: Option<RuleMatch>,
+    pub receive_type: Option<RuleMatchType>,
+}
+
+pub type Rule = (RuleEffect, RulePhase);
+impl TryFrom<RawRule> for Rule {
+    type Error = Error;
+
+    fn try_from(value: RawRule) -> Result<Self, Self::Error> {
+        let (effect, attributes) = match value {
+            RawRule::Allow(attributes) => (RuleEffect::Allow, attributes),
+            RawRule::Deny(attributes) => (RuleEffect::Deny, attributes),
+        };
+        match attributes {
+            RawRuleAttributes {
+                eavesdrop,
+                group: None,
+                own: None,
+                own_prefix: None,
+                receive_error,
+                receive_interface,
+                receive_member,
+                receive_path,
+                receive_requested_reply,
+                receive_sender,
+                receive_type,
+                send_broadcast: None,
+                send_destination: None,
+                send_destination_prefix: None,
+                send_error: None,
+                send_interface: None,
+                send_member: None,
+                send_path: None,
+                send_requested_reply: None,
+                send_type: None,
+                user: None,
+            } => Ok((
+                effect,
+                RulePhase::Receive(ReceiveRule {
+                    eavesdrop,
+                    receive_error,
+                    receive_interface,
+                    receive_member,
+                    receive_path,
+                    receive_requested_reply,
+                    receive_sender,
+                    receive_type,
+                }),
+            )),
+            RawRuleAttributes {
+                eavesdrop,
+                group: None,
+                own: None,
+                own_prefix: None,
+                receive_error: None,
+                receive_interface: None,
+                receive_member: None,
+                receive_path: None,
+                receive_requested_reply: None,
+                receive_sender: None,
+                receive_type: None,
+                send_broadcast,
+                send_destination,
+                send_destination_prefix,
+                send_error,
+                send_interface,
+                send_member,
+                send_path,
+                send_requested_reply,
+                send_type,
+                user: None,
+            } => Ok((
+                effect,
+                RulePhase::Send(SendRule {
+                    eavesdrop,
+                    send_broadcast,
+                    send_destination,
+                    send_destination_prefix,
+                    send_error,
+                    send_interface,
+                    send_member,
+                    send_path,
+                    send_requested_reply,
+                    send_type,
+                }),
+            )),
+            RawRuleAttributes {
+                eavesdrop: None,
+                group: None,
+                own,
+                own_prefix,
+                receive_error: None,
+                receive_interface: None,
+                receive_member: None,
+                receive_path: None,
+                receive_requested_reply: None,
+                receive_sender: None,
+                receive_type: None,
+                send_broadcast: None,
+                send_destination: None,
+                send_destination_prefix: None,
+                send_error: None,
+                send_interface: None,
+                send_member: None,
+                send_path: None,
+                send_requested_reply: None,
+                send_type: None,
+                user: None,
+            } => Ok((effect, RulePhase::Own(OwnRule { own, own_prefix }))),
+            RawRuleAttributes {
+                eavesdrop: None,
+                group,
+                own: None,
+                own_prefix: None,
+                receive_error: None,
+                receive_interface: None,
+                receive_member: None,
+                receive_path: None,
+                receive_requested_reply: None,
+                receive_sender: None,
+                receive_type: None,
+                send_broadcast: None,
+                send_destination: None,
+                send_destination_prefix: None,
+                send_error: None,
+                send_interface: None,
+                send_member: None,
+                send_path: None,
+                send_requested_reply: None,
+                send_type: None,
+                user,
+            } => Ok((effect, RulePhase::Connect(ConnectRule { group, user }))),
+            _ => Err(Error::RuleHasInvalidCombinationOfAttributes),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum RuleEffect {
+    Allow,
+    Deny,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum RulePhase {
+    Connect(ConnectRule),
+    Own(OwnRule),
+    Receive(ReceiveRule),
+    Send(SendRule),
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case", untagged)]
+pub enum RuleMatch {
+    #[serde(rename = "*")]
+    Any,
+    One(String),
+}
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum RuleMatchType {
+    #[serde(rename = "*")]
+    Any,
+    Error,
+    MethodCall,
+    MethodReturn,
+    Signal,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct SendRule {
+    pub eavesdrop: Option<bool>,
+    pub send_broadcast: Option<bool>,
+    pub send_destination: Option<RuleMatch>,
+    pub send_destination_prefix: Option<String>,
+    pub send_error: Option<RuleMatch>,
+    pub send_interface: Option<RuleMatch>,
+    pub send_member: Option<RuleMatch>,
+    pub send_path: Option<RuleMatch>,
+    pub send_requested_reply: Option<bool>,
+    pub send_type: Option<RuleMatchType>,
+}

--- a/src/configuration/raw.rs
+++ b/src/configuration/raw.rs
@@ -5,8 +5,8 @@ use std::{path::PathBuf, str::FromStr};
 use serde::Deserialize;
 
 use super::{
-    ApparmorMode, Associate, IncludeElement, LimitElement, PathBufElement, Principal, RuleMatch,
-    RuleMatchType, Type,
+    ApparmorMode, Associate, IncludeElement, LimitElement, Principal, RuleMatch, RuleMatchType,
+    Type,
 };
 
 #[derive(Clone, Debug, Deserialize, PartialEq)]
@@ -24,14 +24,14 @@ pub(super) struct RawConfiguration {
     pub auth: Vec<String>,
     pub fork: Option<()>,
     pub include: Vec<IncludeElement>,
-    pub includedir: Vec<PathBufElement>,
+    pub includedir: Vec<RawPathBufElement>,
     pub keep_umask: Option<()>,
     pub limit: Vec<LimitElement>,
     pub listen: Vec<String>,
     pub pidfile: Option<PathBuf>,
     pub policy: Vec<RawPolicy>,
     pub selinux: Option<RawSelinux>,
-    pub servicedir: Vec<PathBufElement>,
+    pub servicedir: Vec<RawPathBufElement>,
     pub servicehelper: Option<PathBuf>,
     pub standard_session_servicedirs: Option<()>,
     pub standard_system_servicedirs: Option<()>,
@@ -143,4 +143,13 @@ pub(super) struct RawTypeElement {
 pub(super) struct RawUserElement {
     #[serde(rename = "$text")]
     pub text: Principal,
+}
+
+// reuse this between Vec<PathBuf> fields,
+// except those with field-specific attributes
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub(super) struct RawPathBufElement {
+    #[serde(rename = "$text")]
+    pub text: PathBuf,
 }

--- a/src/configuration/raw.rs
+++ b/src/configuration/raw.rs
@@ -5,8 +5,8 @@ use std::{path::PathBuf, str::FromStr};
 use serde::Deserialize;
 
 use super::{
-    ApparmorMode, Associate, IncludeElement, LimitElement, Principal, RuleMatch, RuleMatchType,
-    Type,
+    policy::{RuleMatch, RuleMatchType},
+    ApparmorMode, Associate, IncludeElement, LimitElement, Principal, Type,
 };
 
 #[derive(Clone, Debug, Deserialize, PartialEq)]

--- a/src/configuration/raw.rs
+++ b/src/configuration/raw.rs
@@ -1,0 +1,146 @@
+//! internal implementation details for handling configuration XML
+
+use std::{path::PathBuf, str::FromStr};
+
+use serde::Deserialize;
+
+use super::{
+    ApparmorMode, Associate, IncludeElement, LimitElement, PathBufElement, Principal, RuleMatch,
+    RuleMatchType, Type,
+};
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub(super) struct RawApparmor {
+    #[serde(rename = "@mode")]
+    pub mode: Option<ApparmorMode>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+#[serde(default)]
+pub(super) struct RawConfiguration {
+    pub allow_anonymous: Option<()>,
+    pub apparmor: Option<RawApparmor>,
+    pub auth: Vec<String>,
+    pub fork: Option<()>,
+    pub include: Vec<IncludeElement>,
+    pub includedir: Vec<PathBufElement>,
+    pub keep_umask: Option<()>,
+    pub limit: Vec<LimitElement>,
+    pub listen: Vec<String>,
+    pub pidfile: Option<PathBuf>,
+    pub policy: Vec<RawPolicy>,
+    pub selinux: Option<RawSelinux>,
+    pub servicedir: Vec<PathBufElement>,
+    pub servicehelper: Option<PathBuf>,
+    pub standard_session_servicedirs: Option<()>,
+    pub standard_system_servicedirs: Option<()>,
+    pub syslog: Option<()>,
+    pub r#type: Vec<RawTypeElement>,
+    pub user: Vec<RawUserElement>,
+}
+impl FromStr for RawConfiguration {
+    type Err = quick_xml::DeError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // TODO: validate expected DOCTYPE
+        // TODO: validate expected root element (busconfig)
+        quick_xml::de::from_str(s)
+    }
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub(super) struct RawPolicy {
+    #[serde(rename = "@at_console")]
+    pub at_console: Option<bool>,
+    #[serde(rename = "@context")]
+    pub context: Option<RawPolicyContext>,
+    #[serde(rename = "@group")]
+    pub group: Option<Principal>,
+    #[serde(default, rename = "$value")]
+    pub rules: Vec<RawRule>,
+    #[serde(rename = "@user")]
+    pub user: Option<Principal>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub(super) enum RawPolicyContext {
+    Default,
+    Mandatory,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub(super) enum RawRule {
+    Allow(RawRuleAttributes),
+    Deny(RawRuleAttributes),
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+#[serde(default, rename_all = "lowercase")]
+pub(super) struct RawRuleAttributes {
+    #[serde(rename = "@send_interface")]
+    pub send_interface: Option<RuleMatch>,
+    #[serde(rename = "@send_member")]
+    pub send_member: Option<RuleMatch>,
+    #[serde(rename = "@send_error")]
+    pub send_error: Option<RuleMatch>,
+    #[serde(rename = "@send_broadcast")]
+    pub send_broadcast: Option<bool>,
+    #[serde(rename = "@send_destination")]
+    pub send_destination: Option<RuleMatch>,
+    #[serde(rename = "@send_destination_prefix")]
+    pub send_destination_prefix: Option<String>,
+    #[serde(rename = "@send_type")]
+    pub send_type: Option<RuleMatchType>,
+    #[serde(rename = "@send_path")]
+    pub send_path: Option<RuleMatch>,
+    #[serde(rename = "@receive_interface")]
+    pub receive_interface: Option<RuleMatch>,
+    #[serde(rename = "@receive_member")]
+    pub receive_member: Option<RuleMatch>,
+    #[serde(rename = "@receive_error")]
+    pub receive_error: Option<RuleMatch>,
+    #[serde(rename = "@receive_sender")]
+    pub receive_sender: Option<RuleMatch>,
+    #[serde(rename = "@receive_type")]
+    pub receive_type: Option<RuleMatchType>,
+    #[serde(rename = "@receive_path")]
+    pub receive_path: Option<RuleMatch>,
+    #[serde(rename = "@send_requested_reply")]
+    pub send_requested_reply: Option<bool>,
+    #[serde(rename = "@receive_requested_reply")]
+    pub receive_requested_reply: Option<bool>,
+    #[serde(rename = "@eavesdrop")]
+    pub eavesdrop: Option<bool>,
+    #[serde(rename = "@own")]
+    pub own: Option<RuleMatch>,
+    #[serde(rename = "@own_prefix")]
+    pub own_prefix: Option<String>,
+    #[serde(rename = "@user")]
+    pub user: Option<RuleMatch>,
+    #[serde(rename = "@group")]
+    pub group: Option<RuleMatch>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+#[serde(default)]
+pub(super) struct RawSelinux {
+    pub associate: Vec<Associate>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub(super) struct RawTypeElement {
+    #[serde(rename = "$text")]
+    pub text: Type,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub(super) struct RawUserElement {
+    #[serde(rename = "$text")]
+    pub text: Principal,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod bus;
+pub mod configuration;
 pub mod fdo;
 pub mod match_rules;
 pub mod name_registry;

--- a/tests/configuration.rs
+++ b/tests/configuration.rs
@@ -5,7 +5,7 @@ use std::{
     str::FromStr,
 };
 
-use busd::configuration::{Configuration, RawConfiguration};
+use busd::configuration::Configuration;
 
 #[test]
 fn find_and_parse_real_configuration_files() {
@@ -30,14 +30,8 @@ fn find_and_parse_real_configuration_files() {
             Err(_) => continue,
         };
 
-        let got = RawConfiguration::from_str(&configuration_text).unwrap_or_else(|err| {
+        Configuration::from_str(&configuration_text).unwrap_or_else(|err| {
             panic!("should correctly parse {}: {err:?}", file_path.display())
-        });
-        Configuration::try_from(got).unwrap_or_else(|err| {
-            panic!(
-                "should validate and convert {}: {err:?}",
-                file_path.display()
-            )
         });
     }
 }

--- a/tests/configuration.rs
+++ b/tests/configuration.rs
@@ -1,0 +1,43 @@
+use std::{
+    ffi::OsStr,
+    fs::{read_dir, read_to_string, DirEntry},
+    path::PathBuf,
+    str::FromStr,
+};
+
+use busd::configuration::{Configuration, RawConfiguration};
+
+#[test]
+fn find_and_parse_real_configuration_files() {
+    let mut file_paths = vec![
+        PathBuf::from("/usr/share/dbus-1/session.conf"),
+        PathBuf::from("/usr/share/dbus-1/system.conf"),
+    ];
+
+    for dir_path in ["/usr/share/dbus-1/session.d", "/usr/share/dbus-1/system.d"] {
+        if let Ok(rd) = read_dir(dir_path) {
+            file_paths.extend(
+                rd.flatten()
+                    .map(|fp| DirEntry::path(&fp))
+                    .filter(|fp| fp.extension() == Some(OsStr::new("conf"))),
+            );
+        }
+    }
+
+    for file_path in file_paths {
+        let configuration_text = match read_to_string(&file_path) {
+            Ok(ok) => ok,
+            Err(_) => continue,
+        };
+
+        let got = RawConfiguration::from_str(&configuration_text).unwrap_or_else(|err| {
+            panic!("should correctly parse {}: {err:?}", file_path.display())
+        });
+        Configuration::try_from(got).unwrap_or_else(|err| {
+            panic!(
+                "should validate and convert {}: {err:?}",
+                file_path.display()
+            )
+        });
+    }
+}


### PR DESCRIPTION
Howdie

I figured I knew just enough Rust to work on this whilst learning how to handle XML in Rust, and thought it'd be just tedious enough that nobody else had started this

Then I realised someone has indeed started this over in #23 , haha!

Anyhow, this uses quick-xml, too, but this PR version models just a little bit more in serde, so it ends up being roughly equivalent with ~20% fewer lines of code (but probably takes slightly longer to compile), but the other PR does do a bit more modeling of what's possible in the `<listen />` elements

I do have an integration test in this PR that runs the XML deserializer against all the real XML configuration files that are found, and it does pass on my system which is promising (although the hard-coded test cases in the other PR are probably the better bet in the long term)

You probably won't end up using this, but perhaps if the other folks take a look there's something salvageable from this attempt

If you do like the look of this, just let me know what blockers I need to fix up to get it into a merge-worthy state

<3