### PR TITLE
Exclude duplicate license file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ rust-version = "1.74"
 repository = "https://github.com/dbus2/busd"
 keywords = ["D-Bus", "DBus", "IPC"]
 categories = ["network-programming"]
+exclude = ["LICENSE"]
 
 [lib]
 name = "busd"


### PR DESCRIPTION
The symlink ends up confusing distribution packaging automation, and should be redundant in uploaded crates anyway.