### PR TITLE
parse XML configuration files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,6 +199,7 @@ dependencies = [
  "futures-util",
  "nix",
  "ntest",
+ "quick-xml",
  "rand",
  "serde",
  "tokio",
@@ -992,6 +993,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.36.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1419,9 +1430,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.19"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
  "matchers",
  "nu-ansi-term",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ console-subscriber = { version = "0.4.0", optional = true }
 xdg-home = "1.1.0"
 event-listener = "5.3.0"
 fastrand = "2.2.0"
+quick-xml = { version = "0.36.2", features = ["serialize"] }
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.29.0", features = ["user"] }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,0 +1,1220 @@
+use std::{
+    env::var,
+    path::{Path, PathBuf},
+    str::FromStr,
+};
+
+use anyhow::{Error, Result};
+use serde::Deserialize;
+use zbus::{Address, AuthMechanism};
+
+mod xml;
+
+use xml::{
+    Document, Element, PolicyContext, PolicyElement, RuleAttributes, RuleElement, TypeElement,
+};
+
+/// The bus configuration.
+///
+/// This is currently only loaded from the [XML configuration files] defined by the specification.
+/// We plan to add support for other formats (e.g JSON) in the future.
+///
+/// [XML configuration files]: https://dbus.freedesktop.org/doc/dbus-daemon.1.html#configuration_file
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+pub struct Config {
+    /// If `true`, connections that authenticated using the ANONYMOUS mechanism will be authorized
+    /// to connect. This option has no practical effect unless the ANONYMOUS mechanism has also
+    /// been enabled using the `auth` option.
+    pub allow_anonymous: bool,
+
+    /// Lists permitted authorization mechanisms.
+    /// If this element doesn't exist, then all known mechanisms are allowed.
+    // TODO: warn when multiple `<auth>` elements are defined, as we only support one
+    // TODO: consider implementing `Deserialize` over in zbus crate, then removing this "skip..."
+    #[serde(default, skip_deserializing)]
+    pub auth: Option<AuthMechanism>,
+
+    /// If `true`, the bus daemon becomes a real daemon (forks into the background, etc.).
+    pub fork: bool,
+
+    /// If `true`, the bus daemon keeps its original umask when forking.
+    /// This may be useful to avoid affecting the behavior of child processes.
+    pub keep_umask: bool,
+
+    /// Address that the bus should listen on.
+    /// The address is in the standard D-Bus format that contains a transport name plus possible
+    /// parameters/options.
+    // TODO: warn when multiple `<listen>` elements are defined, as we only support one
+    // TODO: consider implementing `Deserialize` over in zbus crate, then removing this "skip..."
+    #[serde(default, skip_deserializing)]
+    pub listen: Option<Address>,
+
+    /// The bus daemon will write its pid to the specified file.
+    pub pidfile: Option<PathBuf>,
+
+    pub policies: Vec<Policy>,
+
+    /// Adds a directory to search for .service files,
+    /// which tell the dbus-daemon how to start a program to provide a particular well-known bus
+    /// name.
+    #[serde(default)]
+    pub servicedirs: Vec<PathBuf>,
+
+    /// Specifies the setuid helper that is used to launch system daemons with an alternate user.
+    pub servicehelper: Option<PathBuf>,
+
+    /// If `true`, the bus daemon will log to syslog.
+    pub syslog: bool,
+
+    /// This element only controls which message bus specific environment variables are set in
+    /// activated clients.
+    pub r#type: Option<BusType>,
+
+    /// The user account the daemon should run as, as either a username or a UID.
+    /// If the daemon cannot change to this UID on startup, it will exit.
+    /// If this element is not present, the daemon will not change or care about its UID.
+    pub user: Option<String>,
+}
+
+impl TryFrom<Document> for Config {
+    type Error = Error;
+
+    fn try_from(value: Document) -> std::result::Result<Self, Self::Error> {
+        let mut config = Config::default();
+
+        for element in value.busconfig {
+            match element {
+                Element::AllowAnonymous => config.allow_anonymous = true,
+                Element::Auth(auth) => {
+                    config.auth = Some(AuthMechanism::from_str(&auth)?);
+                }
+                Element::Fork => config.fork = true,
+                Element::Include(_) => {
+                    // NO-OP: removed during `Document::resolve_includes`
+                }
+                Element::Includedir(_) => {
+                    // NO-OP: removed during `Document::resolve_includedirs`
+                }
+                Element::KeepUmask => config.keep_umask = true,
+                Element::Limit => {
+                    // NO-OP: deprecated and ignored
+                }
+                Element::Listen(listen) => {
+                    config.listen = Some(Address::from_str(&listen)?);
+                }
+                Element::Pidfile(p) => config.pidfile = Some(p),
+                Element::Policy(pe) => {
+                    if let Some(p) = OptionalPolicy::try_from(pe)? {
+                        config.policies.push(p);
+                    }
+                }
+                Element::Servicedir(p) => {
+                    config.servicedirs.push(p);
+                }
+                Element::Servicehelper(p) => {
+                    // NOTE: we're assuming this has the same "last one wins" behaviour as `<type>`
+
+                    // TODO: warn and then ignore if we aren't reading:
+                    // /usr/share/dbus-1/system.conf
+                    config.servicehelper = Some(p);
+                }
+                Element::StandardSessionServicedirs => {
+                    // TODO: warn and then ignore if we aren't reading: /etc/dbus-1/session.conf
+                    if let Ok(runtime_dir) = var("XDG_RUNTIME_DIR") {
+                        config
+                            .servicedirs
+                            .push(PathBuf::from(runtime_dir).join("dbus-1/services"));
+                    }
+                    if let Ok(data_dir) = var("XDG_DATA_HOME") {
+                        config
+                            .servicedirs
+                            .push(PathBuf::from(data_dir).join("dbus-1/services"));
+                    }
+                    let mut servicedirs_in_data_dirs = xdg_data_dirs()
+                        .iter()
+                        .map(|p| p.join("dbus-1/services"))
+                        .map(PathBuf::from)
+                        .collect();
+                    config.servicedirs.append(&mut servicedirs_in_data_dirs);
+                    config
+                        .servicedirs
+                        .push(PathBuf::from("/usr/share/dbus-1/services"));
+                    // TODO: add Windows-specific session directories
+                }
+                Element::StandardSystemServicedirs => {
+                    // TODO: warn and then ignore if we aren't reading:
+                    // /usr/share/dbus-1/system.conf
+                    config
+                        .servicedirs
+                        .extend(STANDARD_SYSTEM_SERVICEDIRS.iter().map(PathBuf::from));
+                }
+                Element::Syslog => config.syslog = true,
+                Element::Type(TypeElement { r#type: value }) => config.r#type = Some(value),
+                Element::User(s) => config.user = Some(s),
+            }
+        }
+
+        Ok(config)
+    }
+}
+
+impl Config {
+    pub fn parse(s: &str) -> Result<Self> {
+        // TODO: validate that our DOCTYPE and root element are correct
+        quick_xml::de::from_str::<Document>(s)?.try_into()
+    }
+
+    pub fn read_file(file_path: impl AsRef<Path>) -> Result<Self> {
+        // TODO: error message should contain file path to missing `<include>`
+        Document::read_file(&file_path)?.try_into()
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct ConnectOperation {
+    pub group: Option<String>,
+    pub user: Option<String>,
+}
+
+impl From<RuleAttributes> for ConnectOperation {
+    fn from(value: RuleAttributes) -> Self {
+        Self {
+            group: value.group,
+            user: value.user,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum BusType {
+    Session,
+    System,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum MessageType {
+    #[default]
+    #[serde(rename = "*")]
+    Any,
+    MethodCall,
+    MethodReturn,
+    Signal,
+    Error,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum Name {
+    #[serde(rename = "*")]
+    Any,
+    Exact(String),
+    Prefix(String),
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub enum Operation {
+    /// rules checked when a new connection to the message bus is established
+    Connect(ConnectOperation),
+    /// rules checked when a connection attempts to own a well-known bus names
+    Own(NameOwnership),
+    /// rules that are checked for each recipient of a message
+    Receive(ReceiveOperation),
+    /// rules that are checked when a connection attempts to send a message
+    Send(SendOperation),
+}
+
+type OptionalOperation = Option<Operation>;
+
+impl TryFrom<RuleAttributes> for OptionalOperation {
+    type Error = Error;
+
+    fn try_from(value: RuleAttributes) -> std::result::Result<Self, Self::Error> {
+        let has_connect = value.group.is_some() || value.user.is_some();
+        let has_own = value.own.is_some() || value.own_prefix.is_some();
+        let has_send = value.send_broadcast.is_some()
+            || value.send_destination.is_some()
+            || value.send_destination_prefix.is_some()
+            || value.send_error.is_some()
+            || value.send_interface.is_some()
+            || value.send_member.is_some()
+            || value.send_path.is_some()
+            || value.send_requested_reply.is_some()
+            || value.send_type.is_some();
+        let has_receive = value.receive_error.is_some()
+            || value.receive_interface.is_some()
+            || value.receive_member.is_some()
+            || value.receive_path.is_some()
+            || value.receive_sender.is_some()
+            || value.receive_requested_reply.is_some()
+            || value.receive_type.is_some();
+
+        let operations_count: i8 = vec![has_connect, has_own, has_receive, has_send]
+            .into_iter()
+            .map(i8::from)
+            .sum();
+
+        if operations_count > 1 {
+            return Err(Error::msg(format!("do not mix rule attributes for connect, own, receive, and/or send attributes in the same rule: {value:?}")));
+        }
+
+        if has_connect {
+            Ok(Some(Operation::Connect(ConnectOperation::from(value))))
+        } else if has_own {
+            Ok(Some(Operation::Own(NameOwnership::from(value))))
+        } else if has_receive {
+            Ok(Some(Operation::Receive(ReceiveOperation::from(value))))
+        } else if has_send {
+            Ok(Some(Operation::Send(SendOperation::from(value))))
+        } else {
+            Err(Error::msg(format!("rule must specify supported attributes for connect, own, receive, or send operations: {value:?}")))
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct NameOwnership {
+    pub own: Option<Name>,
+}
+
+impl From<RuleAttributes> for NameOwnership {
+    fn from(value: RuleAttributes) -> Self {
+        let own = match value {
+            RuleAttributes {
+                own: Some(some),
+                own_prefix: None,
+                ..
+            } if some == "*" => Some(Name::Any),
+            RuleAttributes {
+                own: Some(some),
+                own_prefix: None,
+                ..
+            } => Some(Name::Exact(some)),
+            RuleAttributes {
+                own: None,
+                own_prefix: Some(some),
+                ..
+            } => Some(Name::Prefix(some)),
+            _ => None,
+        };
+        Self { own }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub enum Policy {
+    DefaultContext(Vec<Rule>),
+    Group(Vec<Rule>, String),
+    MandatoryContext(Vec<Rule>),
+    User(Vec<Rule>, String),
+}
+// TODO: implement Cmp/Ord to help stable-sort Policy values:
+// DefaultContext < Group < User < MandatoryContext
+
+type OptionalPolicy = Option<Policy>;
+
+impl TryFrom<PolicyElement> for OptionalPolicy {
+    type Error = Error;
+
+    fn try_from(value: PolicyElement) -> std::result::Result<Self, Self::Error> {
+        match value {
+            PolicyElement {
+                at_console: Some(_),
+                context: None,
+                group: None,
+                user: None,
+                ..
+            } => Ok(None),
+            PolicyElement {
+                at_console: None,
+                context: Some(c),
+                group: None,
+                rules,
+                user: None,
+            } => Ok(Some(match c {
+                PolicyContext::Default => {
+                    Policy::DefaultContext(rules_try_from_rule_elements(rules)?)
+                }
+                PolicyContext::Mandatory => {
+                    Policy::MandatoryContext(rules_try_from_rule_elements(rules)?)
+                }
+            })),
+            PolicyElement {
+                at_console: None,
+                context: None,
+                group: Some(group),
+                rules,
+                user: None,
+            } => Ok(Some(Policy::Group(
+                rules_try_from_rule_elements(rules)?,
+                group,
+            ))),
+            PolicyElement {
+                at_console: None,
+                context: None,
+                group: None,
+                rules,
+                user: Some(user),
+            } => Ok(Some(Policy::User(
+                rules_try_from_rule_elements(rules)?,
+                user,
+            ))),
+            _ => Err(Error::msg(format!(
+                "policy contains conflicting attributes: {value:?}"
+            ))),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct ReceiveOperation {
+    pub error: Option<String>,
+    pub interface: Option<String>,
+    pub max_fds: Option<u32>,
+    pub member: Option<String>,
+    pub min_fds: Option<u32>,
+    pub path: Option<String>,
+    pub sender: Option<String>,
+    pub r#type: Option<MessageType>,
+}
+
+impl From<RuleAttributes> for ReceiveOperation {
+    fn from(value: RuleAttributes) -> Self {
+        Self {
+            error: value.receive_error,
+            interface: value.receive_interface,
+            max_fds: value.max_fds,
+            member: value.receive_member,
+            min_fds: value.min_fds,
+            path: value.receive_path,
+            sender: value.receive_sender,
+            r#type: value.receive_type,
+        }
+    }
+}
+
+type OptionalRule = Option<Rule>;
+
+impl TryFrom<RuleElement> for OptionalRule {
+    type Error = Error;
+
+    fn try_from(value: RuleElement) -> std::result::Result<Self, Self::Error> {
+        match value {
+            RuleElement::Allow(RuleAttributes {
+                group: Some(_),
+                user: Some(_),
+                ..
+            })
+            | RuleElement::Deny(RuleAttributes {
+                group: Some(_),
+                user: Some(_),
+                ..
+            }) => Err(Error::msg(format!(
+                "`group` cannot be combined with `user` in the same rule: {value:?}"
+            ))),
+            RuleElement::Allow(RuleAttributes {
+                own: Some(_),
+                own_prefix: Some(_),
+                ..
+            })
+            | RuleElement::Deny(RuleAttributes {
+                own: Some(_),
+                own_prefix: Some(_),
+                ..
+            }) => Err(Error::msg(format!(
+                "`own_prefix` cannot be combined with `own` in the same rule: {value:?}"
+            ))),
+            RuleElement::Allow(RuleAttributes {
+                send_destination: Some(_),
+                send_destination_prefix: Some(_),
+                ..
+            })
+            | RuleElement::Deny(RuleAttributes {
+                send_destination: Some(_),
+                send_destination_prefix: Some(_),
+                ..
+            }) => Err(Error::msg(format!(
+                "`send_destination_prefix` cannot be combined with `send_destination` in the same rule: {value:?}"
+            ))),
+            RuleElement::Allow(RuleAttributes {
+                eavesdrop: Some(true),
+                group: None,
+                own: None,
+                receive_requested_reply: None,
+                receive_sender: None,
+                send_broadcast: None,
+                send_destination: None,
+                send_destination_prefix: None,
+                send_error: None,
+                send_interface: None,
+                send_member: None,
+                send_path: None,
+                send_requested_reply: None,
+                send_type: None,
+                user: None,
+                ..
+            }) => {
+                // see: https://github.com/dbus2/busd/pull/146#issuecomment-2408429760
+                Ok(None)
+            }
+            RuleElement::Allow(
+                RuleAttributes {
+                    receive_requested_reply: Some(false),
+                    ..
+                }
+                | RuleAttributes {
+                    send_requested_reply: Some(false),
+                    ..
+                },
+            ) => {
+                // see: https://github.com/dbus2/busd/pull/146#issuecomment-2408429760
+                Ok(None)
+            }
+            RuleElement::Allow(attrs) => {
+                // if attrs.eavesdrop == Some(true) {
+                // see: https://github.com/dbus2/busd/pull/146#issuecomment-2408429760
+                // }
+                match OptionalOperation::try_from(attrs)? {
+                    Some(some) => Ok(Some((Access::Allow, some))),
+                    None => Ok(None),
+                }
+            }
+            RuleElement::Deny(RuleAttributes {
+                eavesdrop: Some(true),
+                ..
+            }) => {
+                // see: https://github.com/dbus2/busd/pull/146#issuecomment-2408429760
+                Ok(None)
+            }
+            RuleElement::Deny(
+                RuleAttributes {
+                    receive_requested_reply: Some(true),
+                    ..
+                }
+                | RuleAttributes {
+                    send_requested_reply: Some(true),
+                    ..
+                },
+            ) => {
+                // see: https://github.com/dbus2/busd/pull/146#issuecomment-2408429760
+                Ok(None)
+            }
+            RuleElement::Deny(attrs) => match OptionalOperation::try_from(attrs)? {
+                Some(some) => Ok(Some((Access::Deny, some))),
+                None => Ok(None),
+            },
+        }
+    }
+}
+
+pub type Rule = (Access, Operation);
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub enum Access {
+    Allow,
+    Deny,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct SendOperation {
+    pub broadcast: Option<bool>,
+    pub destination: Option<Name>,
+    pub error: Option<String>,
+    pub interface: Option<String>,
+    pub max_fds: Option<u32>,
+    pub member: Option<String>,
+    pub min_fds: Option<u32>,
+    pub path: Option<String>,
+    pub r#type: Option<MessageType>,
+}
+
+impl From<RuleAttributes> for SendOperation {
+    fn from(value: RuleAttributes) -> Self {
+        let destination = match value {
+            RuleAttributes {
+                send_destination: Some(some),
+                send_destination_prefix: None,
+                ..
+            } if some == "*" => Some(Name::Any),
+            RuleAttributes {
+                send_destination: Some(some),
+                send_destination_prefix: None,
+                ..
+            } => Some(Name::Exact(some)),
+            RuleAttributes {
+                send_destination: None,
+                send_destination_prefix: Some(some),
+                ..
+            } => Some(Name::Prefix(some)),
+            _ => None,
+        };
+        Self {
+            broadcast: value.send_broadcast,
+            destination,
+            error: value.send_error,
+            interface: value.send_interface,
+            max_fds: value.max_fds,
+            member: value.send_member,
+            min_fds: value.min_fds,
+            path: value.send_path,
+            r#type: value.send_type,
+        }
+    }
+}
+
+const DEFAULT_DATA_DIRS: &[&str] = &["/usr/local/share", "/usr/share"];
+
+const STANDARD_SYSTEM_SERVICEDIRS: &[&str] = &[
+    "/usr/local/share/dbus-1/system-services",
+    "/usr/share/dbus-1/system-services",
+    "/lib/dbus-1/system-services",
+];
+
+fn rules_try_from_rule_elements(value: Vec<RuleElement>) -> Result<Vec<Rule>> {
+    let mut rules = vec![];
+    for rule in value {
+        let rule = OptionalRule::try_from(rule)?;
+        if let Some(some) = rule {
+            rules.push(some);
+        }
+    }
+    Ok(rules)
+}
+
+fn xdg_data_dirs() -> Vec<PathBuf> {
+    if let Ok(ok) = var("XDG_DATA_DIRS") {
+        return ok.split(":").map(PathBuf::from).collect();
+    }
+    DEFAULT_DATA_DIRS.iter().map(PathBuf::from).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_parse_with_dtd_and_root_element_ok() {
+        let input = r#"<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-Bus Bus Configuration 1.0//EN"
+        "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+        <busconfig></busconfig>
+        "#;
+        Config::parse(input).expect("should parse XML input");
+    }
+
+    #[test]
+    #[should_panic]
+    fn config_parse_with_type_error() {
+        let input = r#"<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-Bus Bus Configuration 1.0//EN"
+        "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+        <busconfig>
+            <type>not-a-valid-message-bus-type</type>
+        </busconfig>
+        "#;
+        Config::parse(input).expect("should parse XML input");
+    }
+
+    #[test]
+    fn config_parse_with_allow_anonymous_and_fork_and_keep_umask_and_syslog_ok() {
+        let input = r#"<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-Bus Bus Configuration 1.0//EN"
+        "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+        <busconfig>
+            <allow_anonymous />
+            <fork />
+            <keep_umask/>
+            <syslog />
+        </busconfig>
+        "#;
+
+        let config = Config::parse(input).expect("should parse XML input");
+
+        assert_eq!(
+            config,
+            Config {
+                allow_anonymous: true,
+                fork: true,
+                keep_umask: true,
+                syslog: true,
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn config_parse_with_auth_ok() {
+        let input = r#"<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-Bus Bus Configuration 1.0//EN"
+        "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+        <busconfig>
+            <auth>ANONYMOUS</auth>
+            <auth>EXTERNAL</auth>
+        </busconfig>
+        "#;
+
+        let config = Config::parse(input).expect("should parse XML input");
+
+        assert_eq!(
+            config,
+            Config {
+                auth: Some(AuthMechanism::External),
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn config_parse_with_limit_ok() {
+        let input = r#"<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-Bus Bus Configuration 1.0//EN"
+        "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+        <busconfig>
+            <limit name="max_incoming_bytes">1000000000</limit>
+        </busconfig>
+        "#;
+
+        Config::parse(input).expect("should parse XML input");
+    }
+
+    #[test]
+    fn config_parse_with_listen_ok() {
+        let input = r#"<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-Bus Bus Configuration 1.0//EN"
+        "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+        <busconfig>
+            <listen>unix:path=/tmp/foo</listen>
+            <listen>tcp:host=localhost,port=1234</listen>
+            <listen>tcp:host=localhost,port=0,family=ipv4</listen>
+        </busconfig>
+        "#;
+
+        let config = Config::parse(input).expect("should parse XML input");
+
+        assert_eq!(
+            config,
+            Config {
+                listen: Some(
+                    Address::from_str("tcp:host=localhost,port=0,family=ipv4")
+                        .expect("should parse address")
+                ),
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn config_parse_with_overlapped_lists_ok() {
+        // confirm this works with/without quick-xml's [`overlapped-lists`] feature
+        // [`overlapped-lists`]: https://docs.rs/quick-xml/latest/quick_xml/#overlapped-lists
+        let input = r#"<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-Bus Bus Configuration 1.0//EN"
+        "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+        <busconfig>
+            <auth>ANONYMOUS</auth>
+            <listen>unix:path=/tmp/foo</listen>
+            <policy context="default">
+                <allow own="*"/>
+                <deny own="*"/>
+                <allow own="*"/>
+            </policy>
+            <auth>EXTERNAL</auth>
+            <listen>tcp:host=localhost,port=1234</listen>
+            <policy context="default">
+                <deny own="*"/>
+                <allow own="*"/>
+                <deny own="*"/>
+            </policy>
+        </busconfig>
+        "#;
+
+        let config = Config::parse(input).expect("should parse XML input");
+
+        assert_eq!(
+            config,
+            Config {
+                auth: Some(AuthMechanism::External),
+                listen: Some(
+                    Address::from_str("tcp:host=localhost,port=1234")
+                        .expect("should parse address")
+                ),
+                policies: vec![
+                    Policy::DefaultContext(vec![
+                        (
+                            Access::Allow,
+                            Operation::Own(NameOwnership {
+                                own: Some(Name::Any)
+                            })
+                        ),
+                        (
+                            Access::Deny,
+                            Operation::Own(NameOwnership {
+                                own: Some(Name::Any)
+                            })
+                        ),
+                        (
+                            Access::Allow,
+                            Operation::Own(NameOwnership {
+                                own: Some(Name::Any)
+                            })
+                        ),
+                    ]),
+                    Policy::DefaultContext(vec![
+                        (
+                            Access::Deny,
+                            Operation::Own(NameOwnership {
+                                own: Some(Name::Any)
+                            })
+                        ),
+                        (
+                            Access::Allow,
+                            Operation::Own(NameOwnership {
+                                own: Some(Name::Any)
+                            })
+                        ),
+                        (
+                            Access::Deny,
+                            Operation::Own(NameOwnership {
+                                own: Some(Name::Any)
+                            })
+                        ),
+                    ]),
+                ],
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn config_parse_with_pidfile_ok() {
+        let input = r#"<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-Bus Bus Configuration 1.0//EN"
+        "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+        <busconfig>
+            <pidfile>/var/run/busd.pid</pidfile>
+        </busconfig>
+        "#;
+
+        let config = Config::parse(input).expect("should parse XML input");
+
+        assert_eq!(
+            config,
+            Config {
+                pidfile: Some(PathBuf::from("/var/run/busd.pid")),
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn config_parse_with_policies_ok() {
+        let input = r#"<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-Bus Bus Configuration 1.0//EN"
+        "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+        <busconfig>
+            <policy context="default">
+                <allow own="org.freedesktop.DBus"/>
+                <allow own_prefix="org.freedesktop"/>
+                <allow group="wheel" />
+                <allow user="root" />
+            </policy>
+            <policy user="root">
+                <allow
+                    send_broadcast="true"
+                    send_destination="org.freedesktop.DBus"
+                    send_error="something bad"
+                    send_interface="org.freedesktop.systemd1.Activator"
+                    send_member="DoSomething"
+                    send_path="/org/freedesktop"
+                    send_type="signal"
+                    max_fds="128"
+                    min_fds="12"
+                    />
+                <allow
+                    receive_error="something bad"
+                    receive_interface="org.freedesktop.systemd1.Activator"
+                    receive_member="DoSomething"
+                    receive_path="/org/freedesktop"
+                    receive_sender="org.freedesktop.DBus"
+                    receive_type="signal"
+                    max_fds="128"
+                    min_fds="12"
+                    />
+            </policy>
+            <policy group="network">
+                <allow send_destination_prefix="org.freedesktop" send_member="DoSomething" />
+                <allow receive_sender="org.freedesktop.Avahi" receive_member="DoSomething"/>
+            </policy>
+            <policy context="mandatory">
+                <deny send_destination="net.connman.iwd"/>
+            </policy>
+        </busconfig>
+        "#;
+
+        let config = Config::parse(input).expect("should parse XML input");
+
+        assert_eq!(
+            config,
+            Config {
+                policies: vec![
+                    Policy::DefaultContext(vec![
+                        (
+                            Access::Allow,
+                            Operation::Own(NameOwnership {
+                                own: Some(Name::Exact(String::from("org.freedesktop.DBus")))
+                            })
+                        ),
+                        (
+                            Access::Allow,
+                            Operation::Own(NameOwnership {
+                                own: Some(Name::Prefix(String::from("org.freedesktop")))
+                            })
+                        ),
+                        (
+                            Access::Allow,
+                            Operation::Connect(ConnectOperation {
+                                group: Some(String::from("wheel")),
+                                user: None,
+                            })
+                        ),
+                        (
+                            Access::Allow,
+                            Operation::Connect(ConnectOperation {
+                                group: None,
+                                user: Some(String::from("root")),
+                            })
+                        ),
+                    ]),
+                    Policy::User(
+                        vec![
+                            (
+                                Access::Allow,
+                                Operation::Send(SendOperation {
+                                    broadcast: Some(true),
+                                    destination: Some(Name::Exact(String::from(
+                                        "org.freedesktop.DBus"
+                                    ))),
+                                    error: Some(String::from("something bad")),
+                                    interface: Some(String::from(
+                                        "org.freedesktop.systemd1.Activator"
+                                    )),
+                                    max_fds: Some(128),
+                                    member: Some(String::from("DoSomething")),
+                                    min_fds: Some(12),
+                                    path: Some(String::from("/org/freedesktop")),
+                                    r#type: Some(MessageType::Signal),
+                                })
+                            ),
+                            (
+                                Access::Allow,
+                                Operation::Receive(ReceiveOperation {
+                                    error: Some(String::from("something bad")),
+                                    interface: Some(String::from(
+                                        "org.freedesktop.systemd1.Activator"
+                                    )),
+                                    max_fds: Some(128),
+                                    member: Some(String::from("DoSomething")),
+                                    min_fds: Some(12),
+                                    path: Some(String::from("/org/freedesktop")),
+                                    sender: Some(String::from("org.freedesktop.DBus")),
+                                    r#type: Some(MessageType::Signal),
+                                })
+                            )
+                        ],
+                        String::from("root")
+                    ),
+                    Policy::Group(
+                        vec![
+                            (
+                                Access::Allow,
+                                Operation::Send(SendOperation {
+                                    broadcast: None,
+                                    destination: Some(Name::Prefix(String::from(
+                                        "org.freedesktop"
+                                    ))),
+                                    error: None,
+                                    interface: None,
+                                    max_fds: None,
+                                    member: Some(String::from("DoSomething")),
+                                    min_fds: None,
+                                    path: None,
+                                    r#type: None
+                                })
+                            ),
+                            // `<allow send_member=...` should be dropped
+                            (
+                                Access::Allow,
+                                Operation::Receive(ReceiveOperation {
+                                    sender: Some(String::from("org.freedesktop.Avahi")),
+                                    error: None,
+                                    interface: None,
+                                    max_fds: None,
+                                    member: Some(String::from("DoSomething")),
+                                    min_fds: None,
+                                    path: None,
+                                    r#type: None
+                                })
+                            ),
+                        ],
+                        String::from("network")
+                    ),
+                    Policy::MandatoryContext(vec![(
+                        Access::Deny,
+                        Operation::Send(SendOperation {
+                            broadcast: None,
+                            destination: Some(Name::Exact(String::from("net.connman.iwd"))),
+                            error: None,
+                            interface: None,
+                            max_fds: None,
+                            member: None,
+                            min_fds: None,
+                            path: None,
+                            r#type: None
+                        })
+                    ),]),
+                ],
+                ..Default::default()
+            }
+        );
+    }
+
+    #[should_panic]
+    #[test]
+    fn config_parse_with_policies_with_group_and_user_error() {
+        let input = r#"<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-Bus Bus Configuration 1.0//EN"
+        "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+        <busconfig>
+            <policy user="root">
+                <allow group="wheel" user="root" />
+            </policy>
+        </busconfig>
+        "#;
+
+        Config::parse(input).expect("should parse XML input");
+    }
+
+    #[test]
+    fn config_parse_with_policies_with_ignored_rules_and_rule_attributes_ok() {
+        let input = r#"<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-Bus Bus Configuration 1.0//EN"
+        "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+        <busconfig>
+            <policy context="default">
+                <allow send_destination="*" eavesdrop="true"/>
+                <allow eavesdrop="true"/>
+                <deny eavesdrop="true"/>
+                <deny send_requested_reply="true" send_type="method_return"/>
+                <allow send_requested_reply="false" send_type="method_return"/>
+                <deny receive_requested_reply="true" receive_type="error"/>
+                <allow receive_requested_reply="false" receive_type="error"/>
+            </policy>
+            <policy at_console="true">
+                <allow send_destination="org.freedesktop.DBus" send_interface="org.freedesktop.systemd1.Activator"/>
+            </policy>
+        </busconfig>
+        "#;
+
+        let config = Config::parse(input).expect("should parse XML input");
+
+        assert_eq!(
+            config,
+            Config {
+                policies: vec![
+                    Policy::DefaultContext(vec![
+                        (
+                            Access::Allow,
+                            // `eavesdrop="true"` is dropped, keep other attributes
+                            Operation::Send(SendOperation {
+                                broadcast: None,
+                                destination: Some(Name::Any),
+                                error: None,
+                                interface: None,
+                                max_fds: None,
+                                member: None,
+                                min_fds: None,
+                                path: None,
+                                r#type: None
+                            })
+                        ),
+                        // `<allow eavesdrop="true"/>` has nothing left after dropping eavesdrop
+                        // `<deny eavesdrop="true" ...` is completely ignored
+                        // `<deny send_requested_reply="true" ...` is completely ignored
+                        // `<allow send_requested_reply="false" ...` is completely ignored
+                        // `<deny receive_requested_reply="true" ...` is completely ignored
+                        // `<allow receive_requested_reply="false" ...` is completely ignored
+                    ]),
+                    // `<policy at_console="true">` is completely ignored
+                ],
+                ..Default::default()
+            }
+        );
+    }
+
+    #[should_panic]
+    #[test]
+    fn config_parse_with_policies_with_own_and_own_prefix_error() {
+        let input = r#"<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-Bus Bus Configuration 1.0//EN"
+        "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+        <busconfig>
+            <policy user="root">
+                <allow own="org.freedesktop.DBus" own_prefix="org.freedesktop" />
+            </policy>
+        </busconfig>
+        "#;
+
+        Config::parse(input).expect("should parse XML input");
+    }
+
+    #[should_panic]
+    #[test]
+    fn config_parse_with_policies_with_send_destination_and_send_destination_prefix_error() {
+        let input = r#"<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-Bus Bus Configuration 1.0//EN"
+        "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+        <busconfig>
+            <policy user="root">
+                <allow send_destination="org.freedesktop.DBus" send_destination_prefix="org.freedesktop" />
+            </policy>
+        </busconfig>
+        "#;
+
+        Config::parse(input).expect("should parse XML input");
+    }
+
+    #[should_panic]
+    #[test]
+    fn config_parse_with_policies_with_send_and_receive_attributes_error() {
+        let input = r#"<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-Bus Bus Configuration 1.0//EN"
+        "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+        <busconfig>
+            <policy user="root">
+                <allow send_destination="org.freedesktop.DBus" receive_sender="org.freedesktop.Avahi" />
+            </policy>
+        </busconfig>
+        "#;
+
+        Config::parse(input).expect("should parse XML input");
+    }
+
+    #[should_panic]
+    #[test]
+    fn config_parse_with_policies_without_attributes_error() {
+        let input = r#"<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-Bus Bus Configuration 1.0//EN"
+        "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+        <busconfig>
+            <policy user="root">
+                <allow />
+            </policy>
+        </busconfig>
+        "#;
+
+        Config::parse(input).expect("should parse XML input");
+    }
+
+    #[test]
+    fn config_parse_with_servicedir_and_standard_session_servicedirs_ok() {
+        let input = r#"<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-Bus Bus Configuration 1.0//EN"
+        "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+        <busconfig>
+            <servicedir>/example</servicedir>
+            <standard_session_servicedirs />
+            <servicedir>/anotherexample</servicedir>
+            <standard_session_servicedirs />
+        </busconfig>
+        "#;
+
+        let config = Config::parse(input).expect("should parse XML input");
+
+        // TODO: improve test: contents are dynamic depending upon environment variables
+        assert_eq!(config.servicedirs.first(), Some(&PathBuf::from("/example")));
+        assert_eq!(
+            config.servicedirs.last(),
+            Some(&PathBuf::from("/usr/share/dbus-1/services"))
+        );
+    }
+
+    #[test]
+    fn config_parse_with_servicedir_and_standard_system_servicedirs_ok() {
+        let input = r#"<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-Bus Bus Configuration 1.0//EN"
+        "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+        <busconfig>
+            <servicedir>/example</servicedir>
+            <standard_system_servicedirs />
+            <servicedir>/anotherexample</servicedir>
+            <standard_system_servicedirs />
+        </busconfig>
+        "#;
+
+        let config = Config::parse(input).expect("should parse XML input");
+
+        assert_eq!(
+            config,
+            Config {
+                servicedirs: vec![
+                    PathBuf::from("/example"),
+                    PathBuf::from("/usr/local/share/dbus-1/system-services"),
+                    PathBuf::from("/usr/share/dbus-1/system-services"),
+                    PathBuf::from("/lib/dbus-1/system-services"),
+                    PathBuf::from("/anotherexample"),
+                    PathBuf::from("/usr/local/share/dbus-1/system-services"),
+                    PathBuf::from("/usr/share/dbus-1/system-services"),
+                    PathBuf::from("/lib/dbus-1/system-services"),
+                ],
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn config_parse_with_servicehelper_ok() {
+        let input = r#"<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-Bus Bus Configuration 1.0//EN"
+        "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+        <busconfig>
+            <servicehelper>/example</servicehelper>
+            <servicehelper>/anotherexample</servicehelper>
+        </busconfig>
+        "#;
+
+        let config = Config::parse(input).expect("should parse XML input");
+
+        assert_eq!(
+            config,
+            Config {
+                servicehelper: Some(PathBuf::from("/anotherexample")),
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn config_parse_with_type_ok() {
+        let input = r#"<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-Bus Bus Configuration 1.0//EN"
+        "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+        <busconfig>
+            <type>session</type>
+            <type>system</type>
+        </busconfig>
+        "#;
+
+        let config = Config::parse(input).expect("should parse XML input");
+
+        assert_eq!(
+            config,
+            Config {
+                r#type: Some(BusType::System),
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn config_parse_with_user_ok() {
+        let input = r#"<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-Bus Bus Configuration 1.0//EN"
+        "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+        <busconfig>
+            <user>1000</user>
+            <user>alice</user>
+        </busconfig>
+        "#;
+
+        let config = Config::parse(input).expect("should parse XML input");
+
+        assert_eq!(
+            config,
+            Config {
+                user: Some(String::from("alice")),
+                ..Default::default()
+            }
+        );
+    }
+}

--- a/src/config/policy.rs
+++ b/src/config/policy.rs
@@ -1,0 +1,72 @@
+use anyhow::Error;
+use serde::Deserialize;
+
+use super::{
+    rule::{rules_try_from_rule_elements, Rule},
+    xml::{PolicyContext, PolicyElement},
+};
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub enum Policy {
+    DefaultContext(Vec<Rule>),
+    Group(Vec<Rule>, String),
+    MandatoryContext(Vec<Rule>),
+    User(Vec<Rule>, String),
+}
+// TODO: implement Cmp/Ord to help stable-sort Policy values:
+// DefaultContext < Group < User < MandatoryContext
+
+pub type OptionalPolicy = Option<Policy>;
+
+impl TryFrom<PolicyElement> for OptionalPolicy {
+    type Error = Error;
+
+    fn try_from(value: PolicyElement) -> std::result::Result<Self, Self::Error> {
+        match value {
+            PolicyElement {
+                at_console: Some(_),
+                context: None,
+                group: None,
+                user: None,
+                ..
+            } => Ok(None),
+            PolicyElement {
+                at_console: None,
+                context: Some(c),
+                group: None,
+                rules,
+                user: None,
+            } => Ok(Some(match c {
+                PolicyContext::Default => {
+                    Policy::DefaultContext(rules_try_from_rule_elements(rules)?)
+                }
+                PolicyContext::Mandatory => {
+                    Policy::MandatoryContext(rules_try_from_rule_elements(rules)?)
+                }
+            })),
+            PolicyElement {
+                at_console: None,
+                context: None,
+                group: Some(group),
+                rules,
+                user: None,
+            } => Ok(Some(Policy::Group(
+                rules_try_from_rule_elements(rules)?,
+                group,
+            ))),
+            PolicyElement {
+                at_console: None,
+                context: None,
+                group: None,
+                rules,
+                user: Some(user),
+            } => Ok(Some(Policy::User(
+                rules_try_from_rule_elements(rules)?,
+                user,
+            ))),
+            _ => Err(Error::msg(format!(
+                "policy contains conflicting attributes: {value:?}"
+            ))),
+        }
+    }
+}

--- a/src/config/rule.rs
+++ b/src/config/rule.rs
@@ -1,0 +1,318 @@
+use anyhow::{Error, Result};
+use serde::Deserialize;
+
+use super::{
+    xml::{RuleAttributes, RuleElement},
+    MessageType, Name,
+};
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct ConnectOperation {
+    pub group: Option<String>,
+    pub user: Option<String>,
+}
+
+impl From<RuleAttributes> for ConnectOperation {
+    fn from(value: RuleAttributes) -> Self {
+        Self {
+            group: value.group,
+            user: value.user,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub enum Operation {
+    /// rules checked when a new connection to the message bus is established
+    Connect(ConnectOperation),
+    /// rules checked when a connection attempts to own a well-known bus names
+    Own(NameOwnership),
+    /// rules that are checked for each recipient of a message
+    Receive(ReceiveOperation),
+    /// rules that are checked when a connection attempts to send a message
+    Send(SendOperation),
+}
+
+type OptionalOperation = Option<Operation>;
+
+impl TryFrom<RuleAttributes> for OptionalOperation {
+    type Error = Error;
+
+    fn try_from(value: RuleAttributes) -> std::result::Result<Self, Self::Error> {
+        let has_connect = value.group.is_some() || value.user.is_some();
+        let has_own = value.own.is_some() || value.own_prefix.is_some();
+        let has_send = value.send_broadcast.is_some()
+            || value.send_destination.is_some()
+            || value.send_destination_prefix.is_some()
+            || value.send_error.is_some()
+            || value.send_interface.is_some()
+            || value.send_member.is_some()
+            || value.send_path.is_some()
+            || value.send_requested_reply.is_some()
+            || value.send_type.is_some();
+        let has_receive = value.receive_error.is_some()
+            || value.receive_interface.is_some()
+            || value.receive_member.is_some()
+            || value.receive_path.is_some()
+            || value.receive_sender.is_some()
+            || value.receive_requested_reply.is_some()
+            || value.receive_type.is_some();
+
+        let operations_count: i8 = vec![has_connect, has_own, has_receive, has_send]
+            .into_iter()
+            .map(i8::from)
+            .sum();
+
+        if operations_count > 1 {
+            return Err(Error::msg(format!("do not mix rule attributes for connect, own, receive, and/or send attributes in the same rule: {value:?}")));
+        }
+
+        if has_connect {
+            Ok(Some(Operation::Connect(ConnectOperation::from(value))))
+        } else if has_own {
+            Ok(Some(Operation::Own(NameOwnership::from(value))))
+        } else if has_receive {
+            Ok(Some(Operation::Receive(ReceiveOperation::from(value))))
+        } else if has_send {
+            Ok(Some(Operation::Send(SendOperation::from(value))))
+        } else {
+            Err(Error::msg(format!("rule must specify supported attributes for connect, own, receive, or send operations: {value:?}")))
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct NameOwnership {
+    pub own: Option<Name>,
+}
+
+impl From<RuleAttributes> for NameOwnership {
+    fn from(value: RuleAttributes) -> Self {
+        let own = match value {
+            RuleAttributes {
+                own: Some(some),
+                own_prefix: None,
+                ..
+            } if some == "*" => Some(Name::Any),
+            RuleAttributes {
+                own: Some(some),
+                own_prefix: None,
+                ..
+            } => Some(Name::Exact(some)),
+            RuleAttributes {
+                own: None,
+                own_prefix: Some(some),
+                ..
+            } => Some(Name::Prefix(some)),
+            _ => None,
+        };
+        Self { own }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct ReceiveOperation {
+    pub error: Option<String>,
+    pub interface: Option<String>,
+    pub max_fds: Option<u32>,
+    pub member: Option<String>,
+    pub min_fds: Option<u32>,
+    pub path: Option<String>,
+    pub sender: Option<String>,
+    pub r#type: Option<MessageType>,
+}
+
+impl From<RuleAttributes> for ReceiveOperation {
+    fn from(value: RuleAttributes) -> Self {
+        Self {
+            error: value.receive_error,
+            interface: value.receive_interface,
+            max_fds: value.max_fds,
+            member: value.receive_member,
+            min_fds: value.min_fds,
+            path: value.receive_path,
+            sender: value.receive_sender,
+            r#type: value.receive_type,
+        }
+    }
+}
+
+type OptionalRule = Option<Rule>;
+
+impl TryFrom<RuleElement> for OptionalRule {
+    type Error = Error;
+
+    fn try_from(value: RuleElement) -> std::result::Result<Self, Self::Error> {
+        match value {
+            RuleElement::Allow(RuleAttributes {
+                group: Some(_),
+                user: Some(_),
+                ..
+            })
+            | RuleElement::Deny(RuleAttributes {
+                group: Some(_),
+                user: Some(_),
+                ..
+            }) => Err(Error::msg(format!(
+                "`group` cannot be combined with `user` in the same rule: {value:?}"
+            ))),
+            RuleElement::Allow(RuleAttributes {
+                own: Some(_),
+                own_prefix: Some(_),
+                ..
+            })
+            | RuleElement::Deny(RuleAttributes {
+                own: Some(_),
+                own_prefix: Some(_),
+                ..
+            }) => Err(Error::msg(format!(
+                "`own_prefix` cannot be combined with `own` in the same rule: {value:?}"
+            ))),
+            RuleElement::Allow(RuleAttributes {
+                send_destination: Some(_),
+                send_destination_prefix: Some(_),
+                ..
+            })
+            | RuleElement::Deny(RuleAttributes {
+                send_destination: Some(_),
+                send_destination_prefix: Some(_),
+                ..
+            }) => Err(Error::msg(format!(
+                "`send_destination_prefix` cannot be combined with `send_destination` in the same rule: {value:?}"
+            ))),
+            RuleElement::Allow(RuleAttributes {
+                eavesdrop: Some(true),
+                group: None,
+                own: None,
+                receive_requested_reply: None,
+                receive_sender: None,
+                send_broadcast: None,
+                send_destination: None,
+                send_destination_prefix: None,
+                send_error: None,
+                send_interface: None,
+                send_member: None,
+                send_path: None,
+                send_requested_reply: None,
+                send_type: None,
+                user: None,
+                ..
+            }) => {
+                // see: https://github.com/dbus2/busd/pull/146#issuecomment-2408429760
+                Ok(None)
+            }
+            RuleElement::Allow(
+                RuleAttributes {
+                    receive_requested_reply: Some(false),
+                    ..
+                }
+                | RuleAttributes {
+                    send_requested_reply: Some(false),
+                    ..
+                },
+            ) => {
+                // see: https://github.com/dbus2/busd/pull/146#issuecomment-2408429760
+                Ok(None)
+            }
+            RuleElement::Allow(attrs) => {
+                // if attrs.eavesdrop == Some(true) {
+                // see: https://github.com/dbus2/busd/pull/146#issuecomment-2408429760
+                // }
+                match OptionalOperation::try_from(attrs)? {
+                    Some(some) => Ok(Some((Access::Allow, some))),
+                    None => Ok(None),
+                }
+            }
+            RuleElement::Deny(RuleAttributes {
+                eavesdrop: Some(true),
+                ..
+            }) => {
+                // see: https://github.com/dbus2/busd/pull/146#issuecomment-2408429760
+                Ok(None)
+            }
+            RuleElement::Deny(
+                RuleAttributes {
+                    receive_requested_reply: Some(true),
+                    ..
+                }
+                | RuleAttributes {
+                    send_requested_reply: Some(true),
+                    ..
+                },
+            ) => {
+                // see: https://github.com/dbus2/busd/pull/146#issuecomment-2408429760
+                Ok(None)
+            }
+            RuleElement::Deny(attrs) => match OptionalOperation::try_from(attrs)? {
+                Some(some) => Ok(Some((Access::Deny, some))),
+                None => Ok(None),
+            },
+        }
+    }
+}
+
+pub type Rule = (Access, Operation);
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub enum Access {
+    Allow,
+    Deny,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct SendOperation {
+    pub broadcast: Option<bool>,
+    pub destination: Option<Name>,
+    pub error: Option<String>,
+    pub interface: Option<String>,
+    pub max_fds: Option<u32>,
+    pub member: Option<String>,
+    pub min_fds: Option<u32>,
+    pub path: Option<String>,
+    pub r#type: Option<MessageType>,
+}
+
+impl From<RuleAttributes> for SendOperation {
+    fn from(value: RuleAttributes) -> Self {
+        let destination = match value {
+            RuleAttributes {
+                send_destination: Some(some),
+                send_destination_prefix: None,
+                ..
+            } if some == "*" => Some(Name::Any),
+            RuleAttributes {
+                send_destination: Some(some),
+                send_destination_prefix: None,
+                ..
+            } => Some(Name::Exact(some)),
+            RuleAttributes {
+                send_destination: None,
+                send_destination_prefix: Some(some),
+                ..
+            } => Some(Name::Prefix(some)),
+            _ => None,
+        };
+        Self {
+            broadcast: value.send_broadcast,
+            destination,
+            error: value.send_error,
+            interface: value.send_interface,
+            max_fds: value.max_fds,
+            member: value.send_member,
+            min_fds: value.min_fds,
+            path: value.send_path,
+            r#type: value.send_type,
+        }
+    }
+}
+
+pub fn rules_try_from_rule_elements(value: Vec<RuleElement>) -> Result<Vec<Rule>> {
+    let mut rules = vec![];
+    for rule in value {
+        let rule = OptionalRule::try_from(rule)?;
+        if let Some(some) = rule {
+            rules.push(some);
+        }
+    }
+    Ok(rules)
+}

--- a/src/config/xml.rs
+++ b/src/config/xml.rs
@@ -63,7 +63,7 @@ impl Document {
                         // we treat `<includedir>` as though it has `ignore_missing="yes"`
                         Err(err) => {
                             warn!(
-                                "should canonicalize directory path '{}': {:?}",
+                                "cannot resolve '<includedir>{}</includedir>' to an absolute path: {}",
                                 &dir_path.display(),
                                 err
                             );
@@ -86,7 +86,11 @@ impl Document {
                         }
                         // we treat `<includedir>` as though it has `ignore_missing="yes"`
                         Err(err) => {
-                            warn!("should read directory '{}': {:?}", &dir_path.display(), err);
+                            warn!(
+                                "cannot read '<includedir>{}</includedir>': {}",
+                                &dir_path.display(),
+                                err
+                            );
                             continue;
                         }
                     }
@@ -128,7 +132,7 @@ impl Document {
                         Ok(ok) => ok,
                         Err(err) => {
                             let msg = format!(
-                                "should canonicalize file path '{}': {:?}",
+                                "cannot resolve '<include>{}</include>' to an absolute path: {}",
                                 &file_path.display(),
                                 err
                             );
@@ -172,7 +176,7 @@ impl Document {
                 .ok_or_else(|| Error::msg("`<include>` path should contain a file name"))?
                 .to_path_buf()),
             None => {
-                warn!("ad-hoc document with unknown file path, using current working directory");
+                warn!("cannot determine file path for this XML document, using current working directory");
                 current_dir().map_err(Error::msg)
             }
         }
@@ -332,12 +336,6 @@ fn resolve_include_path(base_path: impl AsRef<Path>, include_path: impl AsRef<Pa
     if p.is_absolute() {
         return p.to_path_buf();
     }
-
-    error!(
-        "resolve_include_path: {} {}",
-        &base_path.as_ref().display(),
-        &include_path.as_ref().display()
-    );
 
     base_path.as_ref().join(p)
 }

--- a/src/config/xml.rs
+++ b/src/config/xml.rs
@@ -1,0 +1,343 @@
+use std::{
+    env::current_dir,
+    ffi::OsString,
+    fs::{read_dir, read_to_string},
+    path::{Path, PathBuf},
+    str::FromStr,
+};
+
+use anyhow::{Error, Result};
+use serde::Deserialize;
+use tracing::{error, warn};
+
+use super::{BusType, MessageType};
+
+/// The bus configuration.
+///
+/// This is currently only loaded from the [XML configuration files] defined by the specification.
+/// We plan to add support for other formats (e.g JSON) in the future.
+///
+/// [XML configuration files]: https://dbus.freedesktop.org/doc/dbus-daemon.1.html#configuration_file
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+pub struct Document {
+    #[serde(rename = "$value", default)]
+    pub busconfig: Vec<Element>,
+    file_path: Option<PathBuf>,
+}
+
+impl FromStr for Document {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        quick_xml::de::from_str(s).map_err(Error::msg)
+    }
+}
+
+impl Document {
+    pub fn read_file(file_path: impl AsRef<Path>) -> Result<Document> {
+        let text = read_to_string(file_path.as_ref())?;
+
+        let mut doc = Document::from_str(&text)?;
+        doc.file_path = Some(file_path.as_ref().to_path_buf());
+        doc.resolve_includedirs()?.resolve_includes()
+    }
+
+    fn resolve_includedirs(self) -> Result<Document> {
+        let base_path = self.base_path()?;
+        let Document {
+            busconfig,
+            file_path,
+        } = self;
+
+        let mut doc = Document {
+            busconfig: vec![],
+            file_path: None,
+        };
+
+        for el in busconfig {
+            match el {
+                Element::Includedir(dir_path) => {
+                    let dir_path = resolve_include_path(&base_path, &dir_path);
+                    let dir_path = match dir_path.canonicalize() {
+                        Ok(ok) => ok,
+                        // we treat `<includedir>` as though it has `ignore_missing="yes"`
+                        Err(err) => {
+                            warn!(
+                                "should canonicalize directory path '{}': {:?}",
+                                &dir_path.display(),
+                                err
+                            );
+                            continue;
+                        }
+                    };
+                    match read_dir(&dir_path) {
+                        Ok(ok) => {
+                            for entry in ok {
+                                let path = entry?.path();
+                                if path.extension() == Some(&OsString::from("conf"))
+                                    && path.is_file()
+                                {
+                                    doc.busconfig.push(Element::Include(IncludeElement {
+                                        file_path: path,
+                                        ..Default::default()
+                                    }));
+                                }
+                            }
+                        }
+                        // we treat `<includedir>` as though it has `ignore_missing="yes"`
+                        Err(err) => {
+                            warn!("should read directory '{}': {:?}", &dir_path.display(), err);
+                            continue;
+                        }
+                    }
+                }
+                _ => doc.busconfig.push(el),
+            }
+        }
+
+        doc.file_path = file_path;
+        Ok(doc)
+    }
+
+    fn resolve_includes(self) -> Result<Document> {
+        // TODO: implement protection against circular `<include>` references
+        let base_path = self.base_path()?;
+        let Document {
+            busconfig,
+            file_path,
+        } = self;
+
+        let mut doc = Document {
+            busconfig: vec![],
+            file_path: None,
+        };
+
+        for el in busconfig {
+            match el {
+                Element::Include(include) => {
+                    if include.if_selinux_enable == IncludeOption::Yes
+                        || include.selinux_root_relative == IncludeOption::Yes
+                    {
+                        // TODO: implement SELinux support
+                        continue;
+                    }
+
+                    let ignore_missing = include.ignore_missing == IncludeOption::Yes;
+                    let file_path = resolve_include_path(&base_path, &include.file_path);
+                    let file_path = match file_path.canonicalize().map_err(Error::msg) {
+                        Ok(ok) => ok,
+                        Err(err) => {
+                            let msg = format!(
+                                "should canonicalize file path '{}': {:?}",
+                                &file_path.display(),
+                                err
+                            );
+                            if ignore_missing {
+                                warn!(msg);
+                                continue;
+                            }
+                            error!(msg);
+                            return Err(err);
+                        }
+                    };
+                    let mut included = match Document::read_file(&file_path) {
+                        Ok(ok) => ok,
+                        Err(err) => {
+                            let msg = format!(
+                                "'{}' should contain valid XML",
+                                include.file_path.display()
+                            );
+                            if ignore_missing {
+                                warn!(msg);
+                                continue;
+                            }
+                            error!(msg);
+                            return Err(err);
+                        }
+                    };
+                    doc.busconfig.append(&mut included.busconfig);
+                }
+                _ => doc.busconfig.push(el),
+            }
+        }
+
+        doc.file_path = file_path;
+        Ok(doc)
+    }
+
+    fn base_path(&self) -> Result<PathBuf> {
+        match &self.file_path {
+            Some(some) => Ok(some
+                .parent()
+                .ok_or_else(|| Error::msg("`<include>` path should contain a file name"))?
+                .to_path_buf()),
+            None => {
+                warn!("ad-hoc document with unknown file path, using current working directory");
+                current_dir().map_err(Error::msg)
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum Element {
+    AllowAnonymous,
+    Auth(String),
+    Fork,
+    /// Include a file at this point. If the filename is relative, it is located relative to the
+    /// configuration file doing the including.
+    Include(IncludeElement),
+    /// Files in the directory are included in undefined order.
+    /// Only files ending in ".conf" are included.
+    Includedir(PathBuf),
+    KeepUmask,
+    Listen(String),
+    Limit,
+    Pidfile(PathBuf),
+    Policy(PolicyElement),
+    Servicedir(PathBuf),
+    Servicehelper(PathBuf),
+    /// Requests a standard set of session service directories.
+    /// Its effect is similar to specifying a series of <servicedir/> elements for each of the data
+    /// directories, in the order given here.
+    StandardSessionServicedirs,
+    /// Specifies the standard system-wide activation directories that should be searched for
+    /// service files.
+    StandardSystemServicedirs,
+    Syslog,
+    Type(TypeElement),
+    User(String),
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+pub struct IncludeElement {
+    #[serde(default, rename = "@ignore_missing")]
+    ignore_missing: IncludeOption,
+
+    // TODO: implement SELinux
+    #[serde(default, rename = "@if_selinux_enabled")]
+    if_selinux_enable: IncludeOption,
+    #[serde(default, rename = "@selinux_root_relative")]
+    selinux_root_relative: IncludeOption,
+
+    #[serde(rename = "$value")]
+    file_path: PathBuf,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum IncludeOption {
+    #[default]
+    No,
+    Yes,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum PolicyContext {
+    Default,
+    Mandatory,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+pub struct PolicyElement {
+    #[serde(rename = "@at_console")]
+    pub at_console: Option<String>,
+    #[serde(rename = "@context")]
+    pub context: Option<PolicyContext>,
+    #[serde(rename = "@group")]
+    pub group: Option<String>,
+    #[serde(rename = "$value", default)]
+    pub rules: Vec<RuleElement>,
+    #[serde(rename = "@user")]
+    pub user: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+pub struct RuleAttributes {
+    #[serde(rename = "@max_fds")]
+    pub max_fds: Option<u32>,
+    #[serde(rename = "@min_fds")]
+    pub min_fds: Option<u32>,
+
+    #[serde(rename = "@receive_error")]
+    pub receive_error: Option<String>,
+    #[serde(rename = "@receive_interface")]
+    pub receive_interface: Option<String>,
+    /// deprecated and ignored
+    #[serde(rename = "@receive_member")]
+    pub receive_member: Option<String>,
+    #[serde(rename = "@receive_path")]
+    pub receive_path: Option<String>,
+    #[serde(rename = "@receive_sender")]
+    pub receive_sender: Option<String>,
+    #[serde(rename = "@receive_type")]
+    pub receive_type: Option<MessageType>,
+
+    #[serde(rename = "@send_broadcast")]
+    pub send_broadcast: Option<bool>,
+    #[serde(rename = "@send_destination")]
+    pub send_destination: Option<String>,
+    #[serde(rename = "@send_destination_prefix")]
+    pub send_destination_prefix: Option<String>,
+    #[serde(rename = "@send_error")]
+    pub send_error: Option<String>,
+    #[serde(rename = "@send_interface")]
+    pub send_interface: Option<String>,
+    #[serde(rename = "@send_member")]
+    pub send_member: Option<String>,
+    #[serde(rename = "@send_path")]
+    pub send_path: Option<String>,
+    #[serde(rename = "@send_type")]
+    pub send_type: Option<MessageType>,
+
+    /// deprecated and ignored
+    #[serde(rename = "@receive_requested_reply")]
+    pub receive_requested_reply: Option<bool>,
+    /// deprecated and ignored
+    #[serde(rename = "@send_requested_reply")]
+    pub send_requested_reply: Option<bool>,
+
+    /// deprecated and ignored
+    #[serde(rename = "@eavesdrop")]
+    pub eavesdrop: Option<bool>,
+
+    #[serde(rename = "@own")]
+    pub own: Option<String>,
+    #[serde(rename = "@own_prefix")]
+    pub own_prefix: Option<String>,
+
+    #[serde(rename = "@group")]
+    pub group: Option<String>,
+    #[serde(rename = "@user")]
+    pub user: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum RuleElement {
+    Allow(RuleAttributes),
+    Deny(RuleAttributes),
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct TypeElement {
+    #[serde(rename = "$text")]
+    pub r#type: BusType,
+}
+
+fn resolve_include_path(base_path: impl AsRef<Path>, include_path: impl AsRef<Path>) -> PathBuf {
+    let p = include_path.as_ref();
+    if p.is_absolute() {
+        return p.to_path_buf();
+    }
+
+    error!(
+        "resolve_include_path: {} {}",
+        &base_path.as_ref().display(),
+        &include_path.as_ref().display()
+    );
+
+    base_path.as_ref().join(p)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod bus;
+pub mod config;
 pub mod fdo;
 pub mod match_rules;
 pub mod name_registry;

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -1,0 +1,490 @@
+use std::{path::PathBuf, str::FromStr};
+
+use busd::config::{
+    Access, BusType, Config, ConnectOperation, MessageType, Name, NameOwnership, Operation, Policy,
+    ReceiveOperation, SendOperation,
+};
+use zbus::{Address, AuthMechanism};
+
+#[test]
+fn config_read_file_with_includes_ok() {
+    let got =
+        Config::read_file("./tests/data/valid.conf").expect("should read and parse XML input");
+
+    assert_eq!(
+        got,
+        Config {
+            auth: Some(AuthMechanism::External),
+            listen: Some(Address::from_str("unix:path=/tmp/a").expect("should parse address")),
+            policies: vec![
+                Policy::DefaultContext(vec![
+                    (
+                        Access::Allow,
+                        Operation::Own(NameOwnership {
+                            own: Some(Name::Any)
+                        })
+                    ),
+                    (
+                        Access::Deny,
+                        Operation::Own(NameOwnership {
+                            own: Some(Name::Any)
+                        })
+                    ),
+                ]),
+                Policy::MandatoryContext(vec![
+                    (
+                        Access::Deny,
+                        Operation::Own(NameOwnership {
+                            own: Some(Name::Any)
+                        })
+                    ),
+                    (
+                        Access::Allow,
+                        Operation::Own(NameOwnership {
+                            own: Some(Name::Any)
+                        })
+                    ),
+                ],),
+            ],
+            ..Default::default()
+        }
+    );
+}
+
+#[test]
+fn config_read_file_example_session_disable_stats_conf_ok() {
+    let got = Config::read_file("./tests/data/example-session-disable-stats.conf")
+        .expect("should read and parse XML input");
+
+    assert_eq!(
+        got,
+        Config {
+            policies: vec![Policy::DefaultContext(vec![(
+                Access::Deny,
+                Operation::Send(SendOperation {
+                    broadcast: None,
+                    destination: Some(Name::Exact(String::from("org.freedesktop.DBus"))),
+                    error: None,
+                    interface: Some(String::from("org.freedesktop.DBus.Debug.Stats")),
+                    max_fds: None,
+                    member: None,
+                    min_fds: None,
+                    path: None,
+                    r#type: None
+                }),
+            ),]),],
+            ..Default::default()
+        }
+    );
+}
+
+#[test]
+fn config_read_file_example_system_enable_stats_conf_ok() {
+    let got = Config::read_file("./tests/data/example-system-enable-stats.conf")
+        .expect("should read and parse XML input");
+
+    assert_eq!(
+        got,
+        Config {
+            policies: vec![Policy::User(
+                vec![(
+                    Access::Allow,
+                    Operation::Send(SendOperation {
+                        broadcast: None,
+                        destination: Some(Name::Exact(String::from("org.freedesktop.DBus"))),
+                        error: None,
+                        interface: Some(String::from("org.freedesktop.DBus.Debug.Stats")),
+                        max_fds: None,
+                        member: None,
+                        min_fds: None,
+                        path: None,
+                        r#type: None
+                    }),
+                )],
+                String::from("USERNAME"),
+            ),],
+            ..Default::default()
+        }
+    );
+}
+
+#[test]
+fn config_read_file_session_conf_ok() {
+    let mut got =
+        Config::read_file("./tests/data/session.conf").expect("should read and parse XML input");
+
+    assert!(!got.servicedirs.is_empty());
+
+    // nuking this to make it easier to `assert_eq!()`
+    got.servicedirs = vec![];
+
+    assert_eq!(
+        got,
+        Config {
+            listen: Some(
+                Address::from_str("unix:path=/run/user/1000/bus").expect("should parse address")
+            ),
+            keep_umask: true,
+            policies: vec![Policy::DefaultContext(vec![
+                (
+                    Access::Allow,
+                    Operation::Send(SendOperation {
+                        broadcast: None,
+                        destination: Some(Name::Any),
+                        error: None,
+                        interface: None,
+                        max_fds: None,
+                        member: None,
+                        min_fds: None,
+                        path: None,
+                        r#type: None,
+                    }),
+                ),
+                (
+                    Access::Allow,
+                    Operation::Own(NameOwnership {
+                        own: Some(Name::Any),
+                    }),
+                ),
+            ]),],
+            r#type: Some(BusType::Session),
+            ..Default::default()
+        }
+    );
+}
+
+#[test]
+fn config_read_file_system_conf_ok() {
+    let want = Config {
+        auth: Some(AuthMechanism::External),
+        fork: true,
+        listen: Some(
+            Address::from_str("unix:path=/var/run/dbus/system_bus_socket")
+                .expect("should parse address"),
+        ),
+        pidfile: Some(PathBuf::from("@DBUS_SYSTEM_PID_FILE@")),
+        policies: vec![
+            Policy::DefaultContext(vec![
+                (
+                    Access::Allow,
+                    Operation::Connect(ConnectOperation {
+                        group: None,
+                        user: Some(String::from("*")),
+                    }),
+                ),
+                (
+                    Access::Deny,
+                    Operation::Own(NameOwnership {
+                        own: Some(Name::Any),
+                    }),
+                ),
+                (
+                    Access::Deny,
+                    Operation::Send(SendOperation {
+                        broadcast: None,
+                        destination: None,
+                        error: None,
+                        interface: None,
+                        max_fds: None,
+                        member: None,
+                        min_fds: None,
+                        path: None,
+                        r#type: Some(MessageType::MethodCall),
+                    }),
+                ),
+                (
+                    Access::Allow,
+                    Operation::Send(SendOperation {
+                        broadcast: None,
+                        destination: None,
+                        error: None,
+                        interface: None,
+                        max_fds: None,
+                        member: None,
+                        min_fds: None,
+                        path: None,
+                        r#type: Some(MessageType::Signal),
+                    }),
+                ),
+                (
+                    Access::Allow,
+                    Operation::Send(SendOperation {
+                        broadcast: None,
+                        destination: None,
+                        error: None,
+                        interface: None,
+                        max_fds: None,
+                        member: None,
+                        min_fds: None,
+                        path: None,
+                        r#type: Some(MessageType::MethodReturn),
+                    }),
+                ),
+                (
+                    Access::Allow,
+                    Operation::Send(SendOperation {
+                        broadcast: None,
+                        destination: None,
+                        error: None,
+                        interface: None,
+                        max_fds: None,
+                        member: None,
+                        min_fds: None,
+                        path: None,
+                        r#type: Some(MessageType::Error),
+                    }),
+                ),
+                (
+                    Access::Allow,
+                    Operation::Receive(ReceiveOperation {
+                        error: None,
+                        interface: None,
+                        max_fds: None,
+                        member: None,
+                        min_fds: None,
+                        path: None,
+                        sender: None,
+                        r#type: Some(MessageType::MethodCall),
+                    }),
+                ),
+                (
+                    Access::Allow,
+                    Operation::Receive(ReceiveOperation {
+                        error: None,
+                        interface: None,
+                        max_fds: None,
+                        member: None,
+                        min_fds: None,
+                        path: None,
+                        sender: None,
+                        r#type: Some(MessageType::MethodReturn),
+                    }),
+                ),
+                (
+                    Access::Allow,
+                    Operation::Receive(ReceiveOperation {
+                        error: None,
+                        interface: None,
+                        max_fds: None,
+                        member: None,
+                        min_fds: None,
+                        path: None,
+                        sender: None,
+                        r#type: Some(MessageType::Error),
+                    }),
+                ),
+                (
+                    Access::Allow,
+                    Operation::Receive(ReceiveOperation {
+                        error: None,
+                        interface: None,
+                        max_fds: None,
+                        member: None,
+                        min_fds: None,
+                        path: None,
+                        sender: None,
+                        r#type: Some(MessageType::Signal),
+                    }),
+                ),
+                (
+                    Access::Allow,
+                    Operation::Send(SendOperation {
+                        broadcast: None,
+                        destination: Some(Name::Exact(String::from("org.freedesktop.DBus"))),
+                        error: None,
+                        interface: Some(String::from("org.freedesktop.DBus")),
+                        max_fds: None,
+                        member: None,
+                        min_fds: None,
+                        path: None,
+                        r#type: None,
+                    }),
+                ),
+                (
+                    Access::Allow,
+                    Operation::Send(SendOperation {
+                        broadcast: None,
+                        destination: Some(Name::Exact(String::from("org.freedesktop.DBus"))),
+                        error: None,
+                        interface: Some(String::from("org.freedesktop.DBus.Introspectable")),
+                        max_fds: None,
+                        member: None,
+                        min_fds: None,
+                        path: None,
+                        r#type: None,
+                    }),
+                ),
+                (
+                    Access::Allow,
+                    Operation::Send(SendOperation {
+                        broadcast: None,
+                        destination: Some(Name::Exact(String::from("org.freedesktop.DBus"))),
+                        error: None,
+                        interface: Some(String::from("org.freedesktop.DBus.Properties")),
+                        max_fds: None,
+                        member: None,
+                        min_fds: None,
+                        path: None,
+                        r#type: None,
+                    }),
+                ),
+                (
+                    Access::Allow,
+                    Operation::Send(SendOperation {
+                        broadcast: None,
+                        destination: Some(Name::Exact(String::from("org.freedesktop.DBus"))),
+                        error: None,
+                        interface: Some(String::from("org.freedesktop.DBus.Containers1")),
+                        max_fds: None,
+                        member: None,
+                        min_fds: None,
+                        path: None,
+                        r#type: None,
+                    }),
+                ),
+                (
+                    Access::Deny,
+                    Operation::Send(SendOperation {
+                        broadcast: None,
+                        destination: Some(Name::Exact(String::from("org.freedesktop.DBus"))),
+                        error: None,
+                        interface: Some(String::from("org.freedesktop.DBus")),
+                        max_fds: None,
+                        member: Some(String::from("UpdateActivationEnvironment")),
+                        min_fds: None,
+                        path: None,
+                        r#type: None,
+                    }),
+                ),
+                (
+                    Access::Deny,
+                    Operation::Send(SendOperation {
+                        broadcast: None,
+                        destination: Some(Name::Exact(String::from("org.freedesktop.DBus"))),
+                        error: None,
+                        interface: Some(String::from("org.freedesktop.DBus.Debug.Stats")),
+                        max_fds: None,
+                        member: None,
+                        min_fds: None,
+                        path: None,
+                        r#type: None,
+                    }),
+                ),
+                (
+                    Access::Deny,
+                    Operation::Send(SendOperation {
+                        broadcast: None,
+                        destination: Some(Name::Exact(String::from("org.freedesktop.DBus"))),
+                        error: None,
+                        interface: Some(String::from("org.freedesktop.systemd1.Activator")),
+                        max_fds: None,
+                        member: None,
+                        min_fds: None,
+                        path: None,
+                        r#type: None,
+                    }),
+                ),
+            ]),
+            Policy::User(
+                vec![(
+                    Access::Allow,
+                    Operation::Send(SendOperation {
+                        broadcast: None,
+                        destination: Some(Name::Exact(String::from("org.freedesktop.DBus"))),
+                        error: None,
+                        interface: Some(String::from("org.freedesktop.systemd1.Activator")),
+                        max_fds: None,
+                        member: None,
+                        min_fds: None,
+                        path: None,
+                        r#type: None,
+                    }),
+                )],
+                String::from("root"),
+            ),
+            Policy::User(
+                vec![(
+                    Access::Allow,
+                    Operation::Send(SendOperation {
+                        broadcast: None,
+                        destination: Some(Name::Exact(String::from("org.freedesktop.DBus"))),
+                        error: None,
+                        interface: Some(String::from("org.freedesktop.DBus.Monitoring")),
+                        max_fds: None,
+                        member: None,
+                        min_fds: None,
+                        path: None,
+                        r#type: None,
+                    }),
+                )],
+                String::from("root"),
+            ),
+            Policy::User(
+                vec![(
+                    Access::Allow,
+                    Operation::Send(SendOperation {
+                        broadcast: None,
+                        destination: Some(Name::Exact(String::from("org.freedesktop.DBus"))),
+                        error: None,
+                        interface: Some(String::from("org.freedesktop.DBus.Debug.Stats")),
+                        max_fds: None,
+                        member: None,
+                        min_fds: None,
+                        path: None,
+                        r#type: None,
+                    }),
+                )],
+                String::from("root"),
+            ),
+        ],
+        servicehelper: Some(PathBuf::from("@DBUS_LIBEXECDIR@/dbus-daemon-launch-helper")),
+        syslog: true,
+        r#type: Some(BusType::System),
+        user: Some(String::from("@DBUS_USER@")),
+        ..Default::default()
+    };
+
+    let mut got =
+        Config::read_file("./tests/data/system.conf").expect("should read and parse XML input");
+
+    assert!(!got.servicedirs.is_empty());
+
+    // nuking this to make it easier to `assert_eq!()`
+    got.servicedirs = vec![];
+
+    assert_eq!(got, want,);
+}
+
+#[cfg(unix)]
+#[test]
+fn config_read_file_real_usr_share_dbus1_session_conf_ok() {
+    let config_path = PathBuf::from("/usr/share/dbus-1/session.conf");
+    if !config_path.exists() {
+        return;
+    }
+    Config::read_file(config_path).expect("should read and parse XML input");
+}
+
+#[cfg(unix)]
+#[test]
+fn config_read_file_real_usr_share_dbus1_system_conf_ok() {
+    let config_path = PathBuf::from("/usr/share/dbus-1/system.conf");
+    if !config_path.exists() {
+        return;
+    }
+    Config::read_file(config_path).expect("should read and parse XML input");
+}
+
+#[should_panic]
+#[test]
+fn config_read_file_with_missing_include_err() {
+    Config::read_file("./tests/data/missing_include.conf")
+        .expect("should read and parse XML input");
+}
+
+#[should_panic]
+#[test]
+fn config_read_file_with_transitive_missing_include_err() {
+    Config::read_file("./tests/data/transitive_missing_include.conf")
+        .expect("should read and parse XML input");
+}

--- a/tests/data/example-session-disable-stats.conf
+++ b/tests/data/example-session-disable-stats.conf
@@ -1,0 +1,17 @@
+<!-- busd: from: https://gitlab.freedesktop.org/dbus/dbus/-/commit/776e6e0b04a14de4cafc13cc74ffb4a55a23a074 -->
+
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+
+  <!-- If the Stats interface was enabled at compile-time, users can use it on
+       the session bus by default. Systems providing isolation of processes
+       with LSMs might want to restrict this. This can be achieved by copying
+       this file in @EXPANDED_SYSCONFDIR@/dbus-1/session.d/ -->
+
+  <policy context="default">
+    <deny send_destination="org.freedesktop.DBus"
+          send_interface="org.freedesktop.DBus.Debug.Stats"/>
+  </policy>
+
+</busconfig>

--- a/tests/data/example-system-enable-stats.conf
+++ b/tests/data/example-system-enable-stats.conf
@@ -1,0 +1,17 @@
+<!-- busd: from: https://gitlab.freedesktop.org/dbus/dbus/-/commit/776e6e0b04a14de4cafc13cc74ffb4a55a23a074 -->
+
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+
+  <!-- If the Stats interface was enabled at compile-time, only root may use it.
+       Replace USERNAME and copy this file in @EXPANDED_SYSCONFDIR@/dbus-1/system.d/
+       if you want to enable other privileged users to view statistics and
+       debug info -->
+
+  <policy user="USERNAME">
+    <allow send_destination="org.freedesktop.DBus"
+           send_interface="org.freedesktop.DBus.Debug.Stats"/>
+  </policy>
+
+</busconfig>

--- a/tests/data/includedir/a.conf
+++ b/tests/data/includedir/a.conf
@@ -1,0 +1,5 @@
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-Bus Bus Configuration 1.0//EN"
+    "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+    <listen>unix:path=/tmp/a</listen>
+</busconfig>

--- a/tests/data/includedir/not_included.xml
+++ b/tests/data/includedir/not_included.xml
@@ -1,0 +1,5 @@
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-Bus Bus Configuration 1.0//EN"
+    "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+    <listen>unix:path=/tmp/not_included</listen>
+</busconfig>

--- a/tests/data/missing_include.conf
+++ b/tests/data/missing_include.conf
@@ -1,0 +1,5 @@
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-Bus Bus Configuration 1.0//EN"
+    "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+    <include>./missing.conf</include>
+</busconfig>

--- a/tests/data/session.conf
+++ b/tests/data/session.conf
@@ -1,0 +1,83 @@
+<!-- busd: from: https://gitlab.freedesktop.org/dbus/dbus/-/commit/776e6e0b04a14de4cafc13cc74ffb4a55a23a074 -->
+<!-- busd: we've commented out any blocking includes or includedirs -->
+
+<!-- This configuration file controls the per-user-login-session message bus.
+     Add a session-local.conf and edit that rather than changing this 
+     file directly. -->
+
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-Bus Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+  <!-- Our well-known bus type, don't change this -->
+  <type>session</type>
+
+  <!-- If we fork, keep the user's original umask to avoid affecting
+       the behavior of child processes. -->
+  <keep_umask/>
+
+  <listen>unix:path=/run/user/1000/bus</listen>
+
+  <!-- On Unix systems, the most secure authentication mechanism is
+  EXTERNAL, which uses credential-passing over Unix sockets.
+
+  This authentication mechanism is not available on Windows,
+  is not suitable for use with the tcp: or nonce-tcp: transports,
+  and will not work on obscure flavours of Unix that do not have
+  a supported credentials-passing mechanism. On those platforms/transports,
+  comment out the <auth> element to allow fallback to DBUS_COOKIE_SHA1. -->
+  <!-- @DBUS_SESSION_CONF_MAYBE_AUTH_EXTERNAL@ -->
+
+  <standard_session_servicedirs />
+
+  <policy context="default">
+    <!-- Allow everything to be sent -->
+    <allow send_destination="*" eavesdrop="true"/>
+    <!-- Allow everything to be received -->
+    <allow eavesdrop="true"/>
+    <!-- Allow anyone to own anything -->
+    <allow own="*"/>
+  </policy>
+
+  <!-- Include legacy configuration location -->
+  <include ignore_missing="yes">@SYSCONFDIR_FROM_PKGDATADIR@/dbus-1/session.conf</include>
+
+  <!-- Config files are placed here that among other things, 
+       further restrict the above policy for specific services. -->
+  <!-- <includedir>session.d</includedir> -->
+
+  <!-- <includedir>@SYSCONFDIR_FROM_PKGDATADIR@/dbus-1/session.d</includedir> -->
+
+  <!-- This is included last so local configuration can override what's 
+       in this standard file -->
+  <include ignore_missing="yes">@SYSCONFDIR_FROM_PKGDATADIR@/dbus-1/session-local.conf</include>
+
+  <!-- <include if_selinux_enabled="yes" selinux_root_relative="yes">contexts/dbus_contexts</include> -->
+
+  <!-- For the session bus, override the default relatively-low limits 
+       with essentially infinite limits, since the bus is just running 
+       as the user anyway, using up bus resources is not something we need 
+       to worry about. In some cases, we do set the limits lower than 
+       "all available memory" if exceeding the limit is almost certainly a bug, 
+       having the bus enforce a limit is nicer than a huge memory leak. But the 
+       intent is that these limits should never be hit. -->
+
+  <!-- the memory limits are 1G instead of say 4G because they can't exceed 32-bit signed int max -->
+  <limit name="max_incoming_bytes">1000000000</limit>
+  <limit name="max_incoming_unix_fds">250000000</limit>
+  <limit name="max_outgoing_bytes">1000000000</limit>
+  <limit name="max_outgoing_unix_fds">250000000</limit>
+  <limit name="max_message_size">1000000000</limit>
+  <!-- We do not override max_message_unix_fds here since the in-kernel
+       limit is also relatively low -->
+  <limit name="service_start_timeout">120000</limit>  
+  <limit name="auth_timeout">240000</limit>
+  <limit name="pending_fd_timeout">150000</limit>
+  <limit name="max_completed_connections">100000</limit>  
+  <limit name="max_incomplete_connections">10000</limit>
+  <limit name="max_connections_per_user">100000</limit>
+  <limit name="max_pending_service_starts">10000</limit>
+  <limit name="max_names_per_connection">50000</limit>
+  <limit name="max_match_rules_per_connection">50000</limit>
+  <limit name="max_replies_per_connection">50000</limit>
+
+</busconfig>

--- a/tests/data/system.conf
+++ b/tests/data/system.conf
@@ -1,0 +1,145 @@
+<!-- from: https://gitlab.freedesktop.org/dbus/dbus/-/commit/776e6e0b04a14de4cafc13cc74ffb4a55a23a074 -->
+<!-- busd: we've commented out any blocking includes or includedirs -->
+
+<!-- This configuration file controls the systemwide message bus.
+     Add a system-local.conf and edit that rather than changing this 
+     file directly. -->
+
+<!-- Note that there are any number of ways you can hose yourself
+     security-wise by screwing up this file; in particular, you
+     probably don't want to listen on any more addresses, add any more
+     auth mechanisms, run as a different user, etc. -->
+
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-Bus Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+
+  <!-- Our well-known bus type, do not change this -->
+  <type>system</type>
+
+  <!-- Run as special user -->
+  <user>@DBUS_USER@</user>
+
+  <!-- Fork into daemon mode -->
+  <fork/>
+
+  <!-- We use system service launching using a helper -->
+  <standard_system_servicedirs/>
+
+  <!-- This is a setuid helper that is used to launch system services -->
+  <servicehelper>@DBUS_LIBEXECDIR@/dbus-daemon-launch-helper</servicehelper>
+
+  <!-- Write a pid file -->
+  <pidfile>@DBUS_SYSTEM_PID_FILE@</pidfile>
+
+  <!-- Enable logging to syslog -->
+  <syslog/>
+
+  <!-- Only allow socket-credentials-based authentication -->
+  <auth>EXTERNAL</auth>
+
+  <!-- Only listen on a local socket. (abstract=/path/to/socket 
+       means use abstract namespace, don't really create filesystem 
+       file; only Linux supports this. Use path=/whatever on other 
+       systems.) -->
+  <listen>unix:path=/var/run/dbus/system_bus_socket</listen>
+
+  <policy context="default">
+    <!-- All users can connect to system bus -->
+    <allow user="*"/>
+
+    <!-- Holes must be punched in service configuration files for
+         name ownership and sending method calls -->
+    <deny own="*"/>
+    <deny send_type="method_call"/>
+
+    <!-- Signals and reply messages (method returns, errors) are allowed
+         by default -->
+    <allow send_type="signal"/>
+    <allow send_requested_reply="true" send_type="method_return"/>
+    <allow send_requested_reply="true" send_type="error"/>
+
+    <!-- All messages may be received by default -->
+    <allow receive_type="method_call"/>
+    <allow receive_type="method_return"/>
+    <allow receive_type="error"/>
+    <allow receive_type="signal"/>
+
+    <!-- Allow anyone to talk to the message bus -->
+    <allow send_destination="org.freedesktop.DBus"
+           send_interface="org.freedesktop.DBus" />
+    <allow send_destination="org.freedesktop.DBus"
+           send_interface="org.freedesktop.DBus.Introspectable"/>
+    <allow send_destination="org.freedesktop.DBus"
+           send_interface="org.freedesktop.DBus.Properties"/>
+    <allow send_destination="org.freedesktop.DBus"
+           send_interface="org.freedesktop.DBus.Containers1"/>
+    <!-- But disallow some specific bus services -->
+    <deny send_destination="org.freedesktop.DBus"
+          send_interface="org.freedesktop.DBus"
+          send_member="UpdateActivationEnvironment"/>
+    <deny send_destination="org.freedesktop.DBus"
+          send_interface="org.freedesktop.DBus.Debug.Stats"/>
+    <deny send_destination="org.freedesktop.DBus"
+          send_interface="org.freedesktop.systemd1.Activator"/>
+  </policy>
+
+  <!-- Only systemd, which runs as root, may report activation failures. -->
+  <policy user="root">
+    <allow send_destination="org.freedesktop.DBus"
+           send_interface="org.freedesktop.systemd1.Activator"/>
+  </policy>
+
+  <!-- root may monitor the system bus. -->
+  <policy user="root">
+    <allow send_destination="org.freedesktop.DBus"
+           send_interface="org.freedesktop.DBus.Monitoring"/>
+  </policy>
+
+  <!-- If the Stats interface was enabled at compile-time, root may use it.
+       Copy this into system.local.conf or system.d/*.conf if you want to
+       enable other privileged users to view statistics and debug info -->
+  <policy user="root">
+    <allow send_destination="org.freedesktop.DBus"
+           send_interface="org.freedesktop.DBus.Debug.Stats"/>
+  </policy>
+
+  <!-- Include legacy configuration location -->
+  <include ignore_missing="yes">@SYSCONFDIR_FROM_PKGDATADIR@/dbus-1/system.conf</include>
+
+  <!-- The defaults for these limits are hard-coded in dbus-daemon.
+       Some clarifications:
+       Times are in milliseconds (ms); 1000ms = 1 second
+       133169152 bytes = 127 MiB
+       33554432 bytes = 32 MiB
+       150000ms = 2.5 minutes -->
+  <!-- <limit name="max_incoming_bytes">133169152</limit> -->
+  <!-- <limit name="max_incoming_unix_fds">64</limit> -->
+  <!-- <limit name="max_outgoing_bytes">133169152</limit> -->
+  <!-- <limit name="max_outgoing_unix_fds">64</limit> -->
+  <!-- <limit name="max_message_size">33554432</limit> -->
+  <!-- <limit name="max_message_unix_fds">16</limit> -->
+  <!-- <limit name="service_start_timeout">25000</limit> -->
+  <!-- <limit name="auth_timeout">5000</limit> -->
+  <!-- <limit name="pending_fd_timeout">150000</limit> -->
+  <!-- <limit name="max_completed_connections">2048</limit> -->
+  <!-- <limit name="max_incomplete_connections">64</limit> -->
+  <!-- <limit name="max_connections_per_user">256</limit> -->
+  <!-- <limit name="max_pending_service_starts">512</limit> -->
+  <!-- <limit name="max_names_per_connection">512</limit> -->
+  <!-- <limit name="max_match_rules_per_connection">512</limit> -->
+  <!-- <limit name="max_replies_per_connection">128</limit> -->
+
+  <!-- Config files are placed here that among other things, punch 
+       holes in the above policy for specific services. -->
+  <!-- <includedir>system.d</includedir> -->
+
+  <!-- <includedir>@SYSCONFDIR_FROM_PKGDATADIR@/dbus-1/system.d</includedir> -->
+
+  <!-- This is included last so local configuration can override what's 
+       in this standard file -->
+  <include ignore_missing="yes">@SYSCONFDIR_FROM_PKGDATADIR@/dbus-1/system-local.conf</include>
+
+  <!-- <include if_selinux_enabled="yes" selinux_root_relative="yes">contexts/dbus_contexts</include> -->
+
+</busconfig>

--- a/tests/data/transitive_missing_include.conf
+++ b/tests/data/transitive_missing_include.conf
@@ -1,0 +1,5 @@
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-Bus Bus Configuration 1.0//EN"
+    "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+    <include>./missing_include.conf</include>
+</busconfig>

--- a/tests/data/valid.conf
+++ b/tests/data/valid.conf
@@ -1,0 +1,13 @@
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-Bus Bus Configuration 1.0//EN"
+    "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+    <auth>ANONYMOUS</auth>
+    <listen>unix:path=/tmp/foo</listen>
+    <policy context="default">
+        <allow own="*"/>
+        <deny own="*"/>
+    </policy>
+    <include>./valid_included.conf</include>
+    <include ignore_missing="yes">./valid_missing.conf</include>
+    <includedir>./includedir</includedir>
+</busconfig>

--- a/tests/data/valid_included.conf
+++ b/tests/data/valid_included.conf
@@ -1,0 +1,10 @@
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-Bus Bus Configuration 1.0//EN"
+    "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+    <auth>EXTERNAL</auth>
+    <listen>tcp:host=localhost,port=1234</listen>
+    <policy context="mandatory">
+        <deny own="*"/>
+        <allow own="*"/>
+    </policy>
+</busconfig>


### PR DESCRIPTION
based on reading https://dbus.freedesktop.org/doc/dbus-daemon.1.html#configuration_file

Fixes #78 and #79 and #148

Related to #23 and #146

- [x] hardcode `<limit>` parts per #148 
- [x] emit warnings for `<policy>` parts that we don't implement per #79 
- [x] emit warnings for `<policy>` parts that even `dbus-broker` doesn't implement: https://github.com/dbus2/busd/pull/146#issuecomment-2408429760
- [x] `<type>`
- [x] `<user>`
- [x] `<fork>`
- [x] `<keep_umask>`
- [x] `<syslog>`
- [x] `<pidfile>`
- [x] `<allow_anonymous>`
- [x] `<listen>`
- [x] `<auth>`
- [x] `<servicedir>`
- [x] `<include>`
- [x] `<includedir>`
- [x] `<standard_session_servicedirs />`
- [x] all XDG_...-related entries for `<standard_session_servicedirs />`
- [x] `<standard_system_servicedirs />`
- [x] all entries for `<standard_system_servicedirs />`
- [x] `<policy>`
- [x] `<allow>` and all supported attributes
- [x] `<deny>` and all supported attributes
- [x] version real .conf files and tests against them: https://github.com/dbus2/busd/pull/159#issuecomment-2481538852
- [x] read and test against real files from the system if they exist (Linux only?): https://github.com/dbus2/busd/pull/159#issuecomment-2481538852
- [x] `<(allow|deny) send_member=... `: https://github.com/dbus2/busd/issues/79#issuecomment-2482782721
- [x] --config
- [x] --system and --session

TODOs for follow-up PRs:

- [ ] `<selinux>`
- [ ] `<associate>`
- [ ] `<apparmor>`
- [ ] protect against circular `<include>` / `<includedirs>`
- [ ] `<include if_selinux_enabled=...>`
- [ ] `<include selinux_root_relative=...>`
- [ ] `<listen>` better than `String` values (e.g. parse and validate into more useful type)
- [ ] `<auth>` better than `String`, is there an `enum` of specific values we support
- [ ] validate/warn when using `< standard_session_servicedirs />` in a system config
- [ ] validate/warn when using `<standard_system_servicedirs />` in a session config
- [ ] validate DOCTYPE
- [ ] validate root element is `<busconfig>`
- [ ] implement `Ord` / `PartialOrd` trait for `Policy` to facilitate use during evaluation
- [ ] provide default XML configuration files