### PR TITLE
⚡️ Trade compile-time for binary size reduction in release mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,3 +60,4 @@ rand = "0.8.5"
 
 [profile.release]
 lto = "fat"
+codegen-units = 1


### PR DESCRIPTION
This let us remove almost 1MB from the binary size.