### PR TITLE
👷 CONTRIBUTING: Suggest to copy the git hooks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,7 @@ If you intend to contribute often or think that's very likely, we recommend you 
 scripts contained within this repository. You can enable them with:
 
 ```sh
-git config --local core.hooksPath .githooks/
+cp .githooks/* .git/hooks/
 ```
 
 


### PR DESCRIPTION
Instead of configuring a non-standard location as the hooks dir. Otherwise, gimoji (and any other git hooks user may want to use) will not work.