### PR TITLE
🐛 Expose the socket address clients can use

### DIFF
--- a/src/bus/mod.rs
+++ b/src/bus/mod.rs
@@ -61,7 +61,12 @@ impl Bus {
         };
         let (listener, auth_mechanism) = match address.transport() {
             #[cfg(unix)]
-            Transport::Unix(unix) => (Self::unix_stream(unix).await?, AuthMechanism::External),
+            Transport::Unix(unix) => {
+                // Resolve address specification into address that clients can use.
+                let addr = Self::unix_addr(unix)?;
+
+                (Self::unix_stream(addr).await?, AuthMechanism::External)
+            }
             Transport::Tcp(tcp) => {
                 #[cfg(not(windows))]
                 let auth_mechanism = AuthMechanism::Anonymous;
@@ -135,14 +140,10 @@ impl Bus {
     }
 
     #[cfg(unix)]
-    async fn unix_stream(unix: &Unix) -> Result<Listener> {
-        // TODO: Use tokio::net::UnixListener directly once it supports abstract sockets:
-        //
-        // https://github.com/tokio-rs/tokio/issues/4610
-
+    fn unix_addr(unix: &Unix) -> Result<std::os::unix::net::SocketAddr> {
         use std::os::unix::net::SocketAddr;
 
-        let addr = match unix.path() {
+        Ok(match unix.path() {
             #[cfg(target_os = "linux")]
             UnixSocket::Abstract(name) => {
                 use std::os::linux::net::SocketAddrExt;
@@ -175,7 +176,15 @@ impl Bus {
                 addr
             }
             _ => bail!("Unsupported address."),
-        };
+        })
+    }
+
+    #[cfg(unix)]
+    async fn unix_stream(addr: std::os::unix::net::SocketAddr) -> Result<Listener> {
+        // TODO: Use tokio::net::UnixListener directly once it supports abstract sockets:
+        //
+        // https://github.com/tokio-rs/tokio/issues/4610
+
         let std_listener =
             tokio::task::spawn_blocking(move || std::os::unix::net::UnixListener::bind_addr(&addr))
                 .await??;

--- a/src/bus/mod.rs
+++ b/src/bus/mod.rs
@@ -64,8 +64,16 @@ impl Bus {
             Transport::Unix(unix) => {
                 // Resolve address specification into address that clients can use.
                 let addr = Self::unix_addr(unix)?;
+                address = Address::new(Transport::Unix(Unix::new(UnixSocket::File(
+                    addr.as_pathname()
+                        .expect("Address created for UNIX socket should always have a path.")
+                        .to_path_buf(),
+                ))));
 
-                (Self::unix_stream(addr).await?, AuthMechanism::External)
+                (
+                    Self::unix_stream(addr.clone()).await?,
+                    AuthMechanism::External,
+                )
             }
             Transport::Tcp(tcp) => {
                 #[cfg(not(windows))]


### PR DESCRIPTION
This PR ~~takes the `BusType`, `--session`, and `--system` work from #159 . And then builds upon that (perhaps unnecessarily) to fix~~ addresses the issue identified here: https://github.com/dbus2/busd/pull/175#issuecomment-2539367680

i.e. `--print-address` previously didn't always produce a bus address that clients could use.

I've confirmed that the output from `--print-address` can be used with `DBUS_SESSION_BUS_ADDRESS=... cargo test` in the zbus repository