### PR TITLE
🐛 Add previous `guid` to new `address`

### DIFF
--- a/src/bus/mod.rs
+++ b/src/bus/mod.rs
@@ -68,7 +68,8 @@ impl Bus {
                     addr.as_pathname()
                         .expect("Address created for UNIX socket should always have a path.")
                         .to_path_buf(),
-                ))));
+                ))))
+                .set_guid(guid.clone())?;
 
                 (
                     Self::unix_stream(addr.clone()).await?,


### PR DESCRIPTION
We re-add the previous `guid` value to the new `address`.

fixes #192 