### PR TITLE
🔥 Remove a useless conversion

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -138,7 +138,6 @@ impl TryFrom<Document> for Config {
                     let mut servicedirs_in_data_dirs = xdg_data_dirs()
                         .iter()
                         .map(|p| p.join("dbus-1/services"))
-                        .map(PathBuf::from)
                         .collect();
                     config.servicedirs.append(&mut servicedirs_in_data_dirs);
                     config


### PR DESCRIPTION
This fixes a clippy warning:

```rust
warning: useless conversion to the same type: `std::path::PathBuf`
   --> src/config/mod.rs:140:60
    |
140 |                            .map(|p| p.join("dbus-1/services"))
    |   ____________________________________________________________^
    |  |____________________________________________________________|
141 | ||                         .map(PathBuf::from)
    | ||___________________________________________^
142 | |                          .collect();
    | |_________________________- help: consider removing
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_conversion
    = note: `#[warn(clippy::useless_conversion)]` on by default
```