### PR TITLE
⚡️ More binary optimizations for release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,3 +67,10 @@ futures-util = { version = "0.3.30", default-features = true }
 [profile.release]
 lto = "fat"
 codegen-units = 1
+opt-level = "s"
+panic = "abort"
+# generates a seperate *.dwp/*.dSYM so the binary can get stripped
+split-debuginfo = "packed"
+strip = "symbols"
+# No one needs an undebuggable release binary
+debug = "full"


### PR DESCRIPTION
These optimizations reduce the binary size by 40%, which is 3.4M now.

This change also means that we now strip the binary of debug symbols and generate a `busd.dwp` (in the target dir) so that debug symbols are still available when/where needed. Distro packagers should take a note of this.