### PR TITLE
✨ Return success from StartServiceByName if the service is already started

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,7 +165,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1610,12 +1610,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
 name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1624,7 +1630,16 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -1633,14 +1648,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -1650,10 +1682,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1662,10 +1706,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1674,10 +1730,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1686,10 +1754,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
@@ -1721,8 +1801,8 @@ dependencies = [
 
 [[package]]
 name = "zbus"
-version = "5.6.0"
-source = "git+https://github.com/dbus2/zbus/#0820baf62a8804e549f8ec0f5a43a2f4a2e95d55"
+version = "5.9.0"
+source = "git+https://github.com/dbus2/zbus/#6da6b1b5f528fe2d14b0f25ae1dca1a9fd31575c"
 dependencies = [
  "async-broadcast",
  "async-recursion",
@@ -1740,7 +1820,7 @@ dependencies = [
  "tokio",
  "tracing",
  "uds_windows",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
  "winnow",
  "zbus_macros",
  "zbus_names",
@@ -1749,8 +1829,8 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "5.6.0"
-source = "git+https://github.com/dbus2/zbus/#0820baf62a8804e549f8ec0f5a43a2f4a2e95d55"
+version = "5.9.0"
+source = "git+https://github.com/dbus2/zbus/#6da6b1b5f528fe2d14b0f25ae1dca1a9fd31575c"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1764,7 +1844,7 @@ dependencies = [
 [[package]]
 name = "zbus_names"
 version = "4.2.0"
-source = "git+https://github.com/dbus2/zbus/#0820baf62a8804e549f8ec0f5a43a2f4a2e95d55"
+source = "git+https://github.com/dbus2/zbus/#6da6b1b5f528fe2d14b0f25ae1dca1a9fd31575c"
 dependencies = [
  "serde",
  "winnow",
@@ -1793,8 +1873,8 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
-version = "5.5.1"
-source = "git+https://github.com/dbus2/zbus/#0820baf62a8804e549f8ec0f5a43a2f4a2e95d55"
+version = "5.6.0"
+source = "git+https://github.com/dbus2/zbus/#6da6b1b5f528fe2d14b0f25ae1dca1a9fd31575c"
 dependencies = [
  "endi",
  "enumflags2",
@@ -1806,8 +1886,8 @@ dependencies = [
 
 [[package]]
 name = "zvariant_derive"
-version = "5.5.1"
-source = "git+https://github.com/dbus2/zbus/#0820baf62a8804e549f8ec0f5a43a2f4a2e95d55"
+version = "5.6.0"
+source = "git+https://github.com/dbus2/zbus/#6da6b1b5f528fe2d14b0f25ae1dca1a9fd31575c"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1819,7 +1899,7 @@ dependencies = [
 [[package]]
 name = "zvariant_utils"
 version = "3.2.0"
-source = "git+https://github.com/dbus2/zbus/#0820baf62a8804e549f8ec0f5a43a2f4a2e95d55"
+source = "git+https://github.com/dbus2/zbus/#6da6b1b5f528fe2d14b0f25ae1dca1a9fd31575c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/fdo/dbus.rs
+++ b/src/fdo/dbus.rs
@@ -9,6 +9,7 @@ use tracing::warn;
 use zbus::{
     fdo::{
         ConnectionCredentials, Error, ReleaseNameReply, RequestNameFlags, RequestNameReply, Result,
+        StartServiceReply,
     },
     interface, message,
     names::{BusName, InterfaceName, OwnedBusName, OwnedUniqueName, UniqueName, WellKnownName},
@@ -319,8 +320,15 @@ impl DBus {
     }
 
     /// Tries to launch the executable associated with a name (service activation).
-    fn start_service_by_name(&self, _name: WellKnownName<'_>, _flags: u32) -> Result<u32> {
-        // TODO: Implement when we support service activation.
+    async fn start_service_by_name(
+        &self,
+        name: WellKnownName<'_>,
+        _flags: u32,
+    ) -> Result<StartServiceReply> {
+        if self.name_has_owner(name.into()).await? {
+            return Ok(StartServiceReply::AlreadyRunning);
+        }
+        // TODO: Implement further when we support service activation.
         Err(Error::Failed(
             "Service activation not yet supported".to_string(),
         ))

--- a/tests/fdo.rs
+++ b/tests/fdo.rs
@@ -2,6 +2,7 @@ use std::env::temp_dir;
 
 use anyhow::ensure;
 use busd::bus::Bus;
+use enumflags2::BitFlag;
 use futures_util::stream::StreamExt;
 use ntest::timeout;
 use rand::{
@@ -140,7 +141,7 @@ async fn name_ownership_changes_client(address: &str, tx: Sender<()>) -> anyhow:
         .build()
         .await?;
     let ret = dbus_proxy2
-        .request_name(name.clone(), Default::default())
+        .request_name(name.clone(), RequestNameFlags::empty())
         .await?;
 
     // Check that first client is the primary owner before it releases the name.


### PR DESCRIPTION
Some client code (at least [glib's `GDBusProxy`](https://gitlab.gnome.org/GNOME/glib/-/blob/5da569a4253ab4b9a7ff9fcf8595c33f3c324a45/gio/gdbusproxy.c#L1629)) calls `StartServiceByName` and fully errors out when that returns an error, without proceeding to check what `GetNameOwner` says. Let's support this right now.