### PR TITLE
🐛 Fix Hello drop race exposed by tokio 1.51 LIFO stealing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -723,9 +723,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "linux-raw-sys"
@@ -792,13 +792,13 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.3"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1164,12 +1164,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.0"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1225,16 +1225,16 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
 dependencies = [
  "bytes",
  "libc",
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.0",
+ "socket2 0.6.3",
  "tokio-macros",
  "tracing",
  "windows-sys 0.61.2",
@@ -1242,9 +1242,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1311,7 +1311,7 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "socket2 0.6.0",
+ "socket2 0.6.3",
  "sync_wrapper",
  "tokio",
  "tokio-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -360,7 +360,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1045,7 +1045,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1210,7 +1210,7 @@ dependencies = [
  "getrandom 0.3.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1289,7 +1289,7 @@ checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
 dependencies = [
  "indexmap",
  "toml_datetime",
- "winnow",
+ "winnow 0.7.9",
 ]
 
 [[package]]
@@ -1722,6 +1722,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1831,8 +1840,7 @@ dependencies = [
 [[package]]
 name = "zbus"
 version = "5.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca82f95dbd3943a40a53cfded6c2d0a2ca26192011846a1810c4256ef92c60bc"
+source = "git+https://github.com/z-galaxy/zbus#c127e4d88ce8519394ed7d509d33771724d43945"
 dependencies = [
  "async-broadcast",
  "async-recursion",
@@ -1852,7 +1860,7 @@ dependencies = [
  "uds_windows",
  "uuid",
  "windows-sys 0.61.2",
- "winnow",
+ "winnow 1.0.1",
  "zbus_macros",
  "zbus_names",
  "zvariant",
@@ -1861,8 +1869,7 @@ dependencies = [
 [[package]]
 name = "zbus_macros"
 version = "5.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897e79616e84aac4b2c46e9132a4f63b93105d54fe8c0e8f6bffc21fa8d49222"
+source = "git+https://github.com/z-galaxy/zbus#c127e4d88ce8519394ed7d509d33771724d43945"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1876,24 +1883,22 @@ dependencies = [
 [[package]]
 name = "zbus_names"
 version = "4.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffd8af6d5b78619bab301ff3c560a5bd22426150253db278f164d6cf3b72c50f"
+source = "git+https://github.com/z-galaxy/zbus#c127e4d88ce8519394ed7d509d33771724d43945"
 dependencies = [
  "serde",
- "winnow",
+ "winnow 1.0.1",
  "zvariant",
 ]
 
 [[package]]
 name = "zvariant"
 version = "5.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5708299b21903bbe348e94729f22c49c55d04720a004aa350f1f9c122fd2540b"
+source = "git+https://github.com/z-galaxy/zbus#c127e4d88ce8519394ed7d509d33771724d43945"
 dependencies = [
  "endi",
  "enumflags2",
  "serde",
- "winnow",
+ "winnow 1.0.1",
  "zvariant_derive",
  "zvariant_utils",
 ]
@@ -1901,8 +1906,7 @@ dependencies = [
 [[package]]
 name = "zvariant_derive"
 version = "5.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b59b012ebe9c46656f9cc08d8da8b4c726510aef12559da3e5f1bf72780752c"
+source = "git+https://github.com/z-galaxy/zbus#c127e4d88ce8519394ed7d509d33771724d43945"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1914,12 +1918,11 @@ dependencies = [
 [[package]]
 name = "zvariant_utils"
 version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f75c23a64ef8f40f13a6989991e643554d9bef1d682a281160cf0c1bc389c5e9"
+source = "git+https://github.com/z-galaxy/zbus#c127e4d88ce8519394ed7d509d33771724d43945"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde",
  "syn 2.0.117",
- "winnow",
+ "winnow 1.0.1",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,9 @@ name = "busd"
 path = "src/bin/busd.rs"
 
 [dependencies]
-zbus = { version = "5.0", features = [
+# TODO: Switch back to a crates-io version once zbus releases a version with
+# `Builder::build_message_stream`. See https://github.com/z-galaxy/zbus/pull/1760.
+zbus = { git = "https://github.com/z-galaxy/zbus", features = [
     "tokio",
     "bus-impl",
 ], default-features = false }

--- a/src/bus/mod.rs
+++ b/src/bus/mod.rs
@@ -91,12 +91,12 @@ impl Bus {
             .serve_at(fdo::Monitoring::PATH, monitoring)?
             .build()
             .await?;
-        let peer_conn = connection::Builder::authenticated_socket(peer_socket, guid.clone())?
+        let peer_stream = connection::Builder::authenticated_socket(peer_socket, guid.clone())?
             .p2p()
-            .build()
+            .build_message_stream()
             .await?;
 
-        peers.add_us(peer_conn).await;
+        peers.add_us(peer_stream).await;
         trace!("Self-dial connection created.");
 
         Ok(Self {

--- a/src/peer/mod.rs
+++ b/src/peer/mod.rs
@@ -9,7 +9,7 @@ use tracing::trace;
 use zbus::{
     connection::{self, socket::BoxedSplit},
     names::{BusName, OwnedUniqueName},
-    AuthMechanism, Connection, OwnedGuid, OwnedMatchRule,
+    AuthMechanism, Connection, MessageStream, OwnedGuid, OwnedMatchRule,
 };
 
 use crate::{fdo, match_rules::MatchRules, name_registry::NameRegistry};
@@ -30,36 +30,46 @@ impl Peer {
         id: usize,
         socket: BoxedSplit,
         auth_mechanism: AuthMechanism,
-    ) -> Result<Self> {
+    ) -> Result<(Self, Stream)> {
         let unique_name = OwnedUniqueName::try_from(format!(":busd.{id}")).unwrap();
-        let conn = connection::Builder::socket(socket)
+        // Use `build_message_stream` to activate a message receiver before the socket reader
+        // task is spawned, so that messages the client pipelines right after authentication
+        // (notably `Hello`) are never dropped in the race window between `build()` and stream
+        // creation. See https://github.com/z-galaxy/zbus/pull/1760.
+        let msg_stream = connection::Builder::socket(socket)
             .server(guid)?
             .p2p()
             .auth_mechanism(auth_mechanism)
-            .build()
+            .build_message_stream()
             .await?;
+        let conn = Connection::from(&msg_stream);
         trace!("created: {:?}", conn);
 
-        Ok(Self {
+        let peer = Self {
             conn,
             unique_name,
             match_rules: MatchRules::default(),
             greeted: false,
             canceled_event: Event::new(),
-        })
+        };
+        let stream = Stream::for_peer(&peer, msg_stream);
+        Ok((peer, stream))
     }
 
     // This the the bus itself, serving the FDO D-Bus API.
-    pub async fn new_us(conn: Connection) -> Self {
+    pub async fn new_us(msg_stream: MessageStream) -> (Self, Stream) {
         let unique_name = OwnedUniqueName::try_from(fdo::BUS_NAME).unwrap();
+        let conn = Connection::from(&msg_stream);
 
-        Self {
+        let peer = Self {
             conn,
             unique_name,
             match_rules: MatchRules::default(),
             greeted: true,
             canceled_event: Event::new(),
-        }
+        };
+        let stream = Stream::for_peer(&peer, msg_stream);
+        (peer, stream)
     }
 
     pub fn unique_name(&self) -> &OwnedUniqueName {
@@ -68,10 +78,6 @@ impl Peer {
 
     pub fn conn(&self) -> &Connection {
         &self.conn
-    }
-
-    pub fn stream(&self) -> Stream {
-        Stream::for_peer(self)
     }
 
     pub fn listen_cancellation(&self) -> EventListener {

--- a/src/peer/stream.rs
+++ b/src/peer/stream.rs
@@ -20,46 +20,43 @@ pub struct Stream {
 type StreamInner = dyn TryStream<Ok = Message, Error = Error, Item = Result<Message>> + Send;
 
 impl Stream {
-    pub fn for_peer(peer: &Peer) -> Self {
+    pub fn for_peer(peer: &Peer, msg_stream: MessageStream) -> Self {
         let unique_name = peer.unique_name().clone();
-        let stream = MessageStream::from(peer.conn())
-            .map_err(Into::into)
-            .and_then(move |msg| {
-                let unique_name = unique_name.clone();
-                async move {
-                    let header = msg.header();
+        let stream = msg_stream.map_err(Into::into).and_then(move |msg| {
+            let unique_name = unique_name.clone();
+            async move {
+                let header = msg.header();
 
-                    // Ensure destination field is present and readable for non-signals.
-                    if msg.message_type() != message::Type::Signal && header.destination().is_none()
-                    {
-                        bail!("missing destination field");
-                    }
+                // Ensure destination field is present and readable for non-signals.
+                if msg.message_type() != message::Type::Signal && header.destination().is_none() {
+                    bail!("missing destination field");
+                }
 
-                    // Ensure sender field is present. If it is not we add it using the unique name
-                    // of the peer.
-                    match header.sender() {
-                        Some(sender) if *sender == unique_name => Ok(msg),
-                        Some(_) => bail!("failed to parse message: Invalid sender field"),
-                        None => {
-                            let signature = header.signature();
-                            let body = msg.body();
-                            let body_bytes = body.data();
-                            let fds = body_bytes
-                                .fds()
-                                .iter()
-                                .map(|fd| fd.try_clone().map(Into::into))
-                                .collect::<zbus::zvariant::Result<Vec<_>>>()?;
-                            let builder =
-                                message::Builder::from(header.clone()).sender(&unique_name)?;
-                            let new_msg =
-                                unsafe { builder.build_raw_body(body_bytes, signature, fds)? };
-                            trace!("Added sender field to message: {:?}", new_msg);
+                // Ensure sender field is present. If it is not we add it using the unique name
+                // of the peer.
+                match header.sender() {
+                    Some(sender) if *sender == unique_name => Ok(msg),
+                    Some(_) => bail!("failed to parse message: Invalid sender field"),
+                    None => {
+                        let signature = header.signature();
+                        let body = msg.body();
+                        let body_bytes = body.data();
+                        let fds = body_bytes
+                            .fds()
+                            .iter()
+                            .map(|fd| fd.try_clone().map(Into::into))
+                            .collect::<zbus::zvariant::Result<Vec<_>>>()?;
+                        let builder =
+                            message::Builder::from(header.clone()).sender(&unique_name)?;
+                        let new_msg =
+                            unsafe { builder.build_raw_body(body_bytes, signature, fds)? };
+                        trace!("Added sender field to message: {:?}", new_msg);
 
-                            Ok(new_msg)
-                        }
+                        Ok(new_msg)
                     }
                 }
-            });
+            }
+        });
 
         Self {
             stream: Box::pin(stream),

--- a/src/peers.rs
+++ b/src/peers.rs
@@ -52,7 +52,7 @@ impl Peers {
         auth_mechanism: AuthMechanism,
     ) -> Result<()> {
         let mut peers = self.peers_mut().await;
-        let peer = Peer::new(guid.clone(), id, socket, auth_mechanism).await?;
+        let (peer, peer_stream) = Peer::new(guid.clone(), id, socket, auth_mechanism).await?;
         let unique_name = peer.unique_name().clone();
         match peers.get(&unique_name) {
             Some(peer) => panic!(
@@ -60,7 +60,6 @@ impl Peers {
                 peer.unique_name()
             ),
             None => {
-                let peer_stream = peer.stream();
                 let listener = peer.listen_cancellation();
                 tokio::spawn(
                     self.clone()
@@ -73,9 +72,9 @@ impl Peers {
         Ok(())
     }
 
-    pub async fn add_us(self: &Arc<Self>, conn: zbus::Connection) {
+    pub async fn add_us(self: &Arc<Self>, msg_stream: zbus::MessageStream) {
         let mut peers = self.peers_mut().await;
-        let peer = Peer::new_us(conn).await;
+        let (peer, peer_stream) = Peer::new_us(msg_stream).await;
         let unique_name = peer.unique_name().clone();
         match peers.get(&unique_name) {
             Some(peer) => panic!(
@@ -83,7 +82,6 @@ impl Peers {
                 peer.unique_name()
             ),
             None => {
-                let peer_stream = peer.stream();
                 let listener = peer.listen_cancellation();
                 tokio::spawn(
                     self.clone()

--- a/tests/monitor.rs
+++ b/tests/monitor.rs
@@ -19,7 +19,7 @@ use zbus::{
 async fn become_monitor() {
     busd::tracing_subscriber::init();
 
-    let address = "tcp:host=127.0.0.1,port=4242".to_string();
+    let address = "tcp:host=127.0.0.1,port=4244".to_string();
     let mut bus = Bus::for_address(Some(&address)).await.unwrap();
     let (tx, rx) = tokio::sync::oneshot::channel();
 


### PR DESCRIPTION
## Summary

This PR resolves the `multi_conenct` test hang that shows up once tokio is bumped to 1.51.x, via three atomic commits:

1. **`✅ Resolve a TCP port conflict between 2 tests`** — `fdo` and `monitor` were both binding port 4242, causing non-deterministic failures under parallel `cargo test`. Switch `monitor` to 4244.
2. **`⬆️ Update tokio to v1.51.1`** — the actual dependency bump. On its own, this commit makes CI flaky: `multi_conenct` starts timing out at 30s in ~20-40% of runs.
3. **`🐛 Use zbus Builder::build_message_stream to avoid dropping Hello`** — the real fix.

## Root cause of the `multi_conenct` hang

tokio 1.51.0 introduced LIFO slot stealing ([tokio-rs/tokio#7431](https://github.com/tokio-rs/tokio/pull/7431)): a task freshly `spawn`ed into a worker's LIFO slot can now be stolen by another worker and start running before the spawning task yields. This exposes a pre-existing race in zbus's `Connection::Builder::build()`:

- `build()` calls `conn.init_socket_reader(...)` near the end, which spawns the per-connection socket-reader task.
- The unfiltered broadcast channel's receiver is created deactivated (`await_active: false`); it's only activated when someone later calls `MessageStream::from(&conn)`.
- Under tokio 1.51, the socket-reader can now start running **before `build()` returns** to busd's `Peer::new`. If it reads a client's pipelined `Hello` and calls `broadcast_direct()`, `async-broadcast` returns `TrySendError::Inactive` immediately (no active receivers, `await_active` is false). zbus's socket-reader swallows this error for the generic stream, so **the `Hello` is silently dropped**.
- busd's `Peers::add` then spawns `serve_peer`, whose `MessageStream::from(peer.conn())` finally activates a receiver — but the broadcast channel is empty. The affected client hangs forever waiting for its `Hello` reply, and `join_all` in the test never completes.

Evidence from a hanging run (see trace in `/tmp/test_trace2.log`): 10 `Hello`s read from the wire by the per-peer socket readers, but only 8 `Added sender field` lines in `busd::peer::stream` — two clients' `Hello`s silently dropped. The surviving 8 `DBus::hello` invocations run to completion, so this is clearly a dropped-message race, not a lock cycle.

## The fix

The race cannot be closed from the busd side alone: the socket-reader task is spawned **inside** `build()`, so even if busd were to activate the receiver the instant `build()` returned, it would still lose the race under LIFO stealing.

Upstream zbus PR [z-galaxy/zbus#1760](https://github.com/z-galaxy/zbus/pull/1760) adds `connection::Builder::build_message_stream` (and the blocking counterpart `build_message_iterator`), which activates a receiver on the unfiltered broadcast channel **before** `init_socket_reader` spawns the reader task. This closes the race window entirely.

On the busd side:

- `Peer::new` now returns `(Peer, Stream)`, built via `build_message_stream()`. `Connection::from(&msg_stream)` gives us the `Connection` to store in the struct (cheap `Arc` clone).
- `Peer::new_us` takes a `MessageStream` instead of a `Connection`, so the self-dial peer gets the same race-free treatment.
- `Peers::{add, add_us}` destructure `(Peer, Stream)` and drop the now-unused `peer.stream()` accessor.
- `src/bus/mod.rs` builds the self-dial `peer_stream` via `build_message_stream()` too.
- `Cargo.toml` pins zbus to the PR commit via `[patch.crates-io]`. This will be replaced with a normal version bump once zbus 5.15 (containing `build_message_stream`) is released.

## Test plan

- [x] `cargo --locked test --test multiple_conns` in a 20-run loop: **20/20 pass** (previously ≥ 2/10 would time out at 30s on this tree).
- [x] `cargo --locked test` full suite: all integration tests green (`config`, `fdo`, `greet`, `monitor`, `multiple_conns`).
- [x] `cargo fmt --check` clean.
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] CI green on ubuntu-latest + macos-latest × stable + nightly after force-push.