### PR TITLE
📝 Document top-down module ordering; add AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,53 @@
+# AGENTS.md
+
+This file provides guidance to AI coding agents when working with code in this repository.
+
+For contribution conventions — commit-message format, atomic commits, code layout, and
+more — follow the guidelines in [`CONTRIBUTING.md`](CONTRIBUTING.md).
+
+## Project Overview
+
+busd is a pure-Rust D-Bus bus (broker) implementation — the sibling daemon to the [zbus]
+library, which it builds on (via zbus's `bus-impl` feature). Being pure Rust, it
+cross-builds far more easily than the reference C broker. Status is alpha: only the
+essentials of the D-Bus specification are in place.
+
+[zbus]: https://github.com/z-galaxy/zbus
+
+## Development Commands
+
+```bash
+# Build
+cargo build
+cargo build --release
+
+# Run a session bus and print its address
+cargo run -- --print-address
+
+# Test (integration tests live in tests/, e.g. config parsing)
+cargo test
+
+# Format (nightly rustfmt) and lint
+cargo +nightly fmt --all
+cargo clippy -- -D warnings
+```
+
+## Architecture
+
+The crate is both a library (`src/lib.rs`) and a thin CLI binary (`src/bin/busd.rs`,
+argument parsing via clap). Key modules:
+
+- **`bus/`** — the broker core: accepts peer connections and routes messages between them.
+- **`peer/`, `peers.rs`** — per-connection peer state and the set of connected peers,
+  including monitor (eavesdropping) support.
+- **`name_registry.rs`** — ownership of well-known bus names.
+- **`match_rules.rs`** — match-rule parsing and signal delivery.
+- **`fdo/`** — the standard `org.freedesktop.DBus` interfaces (`dbus.rs`) and monitoring
+  (`monitoring.rs`).
+- **`config/`** — bus configuration file parsing: `xml.rs` (the `.conf` format),
+  `policy.rs` and `rule.rs` (access-control policy).
+- **`tracing_subscriber.rs`** — logging setup (behind the default `tracing-subscriber`
+  feature).
+
+busd tracks zbus's git `main` (see the note in `Cargo.toml`), so bus-side changes there
+can require updating this crate.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,14 @@ Same rules apply here as for bug reports and feature requests. Plus:
   [`git-revise`](https://github.com/mystor/git-revise) extremely useful, especially if you're not
   very familiar with interactive rebasing and modifying commits in git.
 
+### Code layout
+
+Within a module, order items top-down, [as rustls does](https://github.com/rustls/rustls/blob/main/CONTRIBUTING.md#top-down-ordering-within-modules):
+items depend on items defined *below* them, not above. In practice: the
+public API sits near the top of the file, private helpers below the code
+that calls them, simple `const`s below their users, and `#[cfg(test)] mod
+tests` at the very bottom.
+
 ### Legal Notice
 
 When contributing to this project, you **implicitly** declare that:


### PR DESCRIPTION
Brings the top-down module-ordering convention (documented in pixel8) to this repo, and gives busd an `AGENTS.md` like its sibling repos.

- **📝 Document top-down module ordering** in `CONTRIBUTING.md` (a new `### Code layout` section, the way rustls documents the same rule).
- **📝 Add `AGENTS.md`** — project overview, build/test/lint commands, and a module map — pointing at `CONTRIBUTING.md` for the conventions, with a `CLAUDE.md` symlink so tools that look for that name still find it. busd previously had no agent-guidance file, so this content is new and worth a review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017hsPwJedhjrYeW8zyqiUcs

---
_Generated by [Claude Code](https://claude.ai/code/session_017hsPwJedhjrYeW8zyqiUcs)_