### PR TITLE
🧵 Don't hold the peers lock during connection setup

### DIFF
--- a/src/config/xml.rs
+++ b/src/config/xml.rs
@@ -133,7 +133,7 @@ impl Document {
                         Err(err) => {
                             let msg = format!(
                                 "cannot resolve '<include>{}</include>' to an absolute path: {}",
-                                &file_path.display(),
+                                file_path.display(),
                                 err
                             );
                             if ignore_missing {

--- a/src/peers.rs
+++ b/src/peers.rs
@@ -51,16 +51,20 @@ impl Peers {
         socket: BoxedSplit,
         auth_mechanism: AuthMechanism,
     ) -> Result<()> {
-        let mut peers = self.peers_mut().await;
+        // Perform the connection build and SASL handshake without holding the peers lock, as it
+        // involves async I/O and would otherwise block all other peer operations (Hello
+        // handling, etc.).
         let (peer, peer_stream) = Peer::new(guid.clone(), id, socket, auth_mechanism).await?;
         let unique_name = peer.unique_name().clone();
+        let listener = peer.listen_cancellation();
+
+        let mut peers = self.peers_mut().await;
         match peers.get(&unique_name) {
             Some(peer) => panic!(
                 "Unique name `{}` re-used. We're in deep trouble if this happens",
                 peer.unique_name()
             ),
             None => {
-                let listener = peer.listen_cancellation();
                 tokio::spawn(
                     self.clone()
                         .serve_peer(peer_stream, listener, unique_name.clone()),
@@ -73,16 +77,17 @@ impl Peers {
     }
 
     pub async fn add_us(self: &Arc<Self>, msg_stream: zbus::MessageStream) {
-        let mut peers = self.peers_mut().await;
         let (peer, peer_stream) = Peer::new_us(msg_stream).await;
         let unique_name = peer.unique_name().clone();
+        let listener = peer.listen_cancellation();
+
+        let mut peers = self.peers_mut().await;
         match peers.get(&unique_name) {
             Some(peer) => panic!(
                 "Unique name `{}` re-used. We're in deep trouble if this happens",
                 peer.unique_name()
             ),
             None => {
-                let listener = peer.listen_cancellation();
                 tokio::spawn(
                     self.clone()
                         .serve_peer(peer_stream, listener, unique_name.clone()),


### PR DESCRIPTION
`Peers::add()` / `add_us()` acquired the `peers` write lock *before* calling
`Peer::new()` / `Peer::new_us()`, which perform the async connection build and SASL
handshake (`build_message_stream().await`). Holding the write lock across that async I/O
serializes every peer operation — Hello handling, message routing, etc. — so a single slow
or stalled client can block the entire bus.

This builds the peer first and takes the lock only for the map lookup and insertion.

## Context

This is the surviving, still-relevant part of a stale `test-fixes` branch, rebased onto
current `main`. Its other changes were dropped as already-landed:

- The TCP port-conflict test fix was already merged (byte-identical patch).
- The "`Hello` dropped in the build/stream race" fix is already on `main` via the
  `build_message_stream()` change, which supersedes the branch's earlier approach.

## Testing

- `cargo build` — clean
- `cargo +nightly fmt --all -- --check` — clean
- `cargo clippy --all-features -- -D warnings` — clean
- `RUSTFLAGS="--cfg tokio_unstable" cargo test --all-features` — 33 passed

The `tokio_unstable` flag is required for the `console-subscriber` feature to initialize
under `--all-features`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PUNTonRr1mtapHsbFgW8ev
